### PR TITLE
Fix typecheck + mypy strict typing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ install:
 # Run all tests
 test:
 	@echo "Running tests..."
-	@pytest
+	@.venv/bin/pytest
 
 # Run type checker
 typecheck:
 	@echo "Running type checker..."
-	@mypy src/
+	@.venv/bin/mypy src/
 
 # Run linter
 lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ warn_no_return = true
 strict_equality = true
 strict_concatenate = true
 
+[[tool.mypy.overrides]]
+module = ["yaml", "yaml.*"]
+ignore_missing_imports = true
+
 [tool.ruff]
 target-version = "py313"
 line-length = 100

--- a/src/assistant/adapters/source.py
+++ b/src/assistant/adapters/source.py
@@ -15,6 +15,14 @@ class ExternalSource(ABC):
     documents from external systems.
     """
 
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Initialize the external source implementation.
+
+        Args:
+            config: Provider-specific configuration dictionary.
+        """
+        self._config = config
+
     @abstractmethod
     def get_document(self, external_id: str) -> DocumentContent:
         """Fetch a document by its external ID.

--- a/src/assistant/models/schema.py
+++ b/src/assistant/models/schema.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import uuid
+import uuid as uuid_module
 from datetime import datetime  # noqa: TC003
 from enum import Enum
-from typing import ClassVar
 
 from sqlalchemy import DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID
@@ -37,12 +36,12 @@ class Document(Base):
     """
 
     __tablename__ = "documents"
-    __table_args__: ClassVar[dict[str, str]] = {"schema": "assistant"}
+    __table_args__ = {"schema": "assistant"}  # noqa: RUF012
 
-    uuid: Mapped[uuid.UUID] = mapped_column(
+    uuid: Mapped[uuid_module.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
-        default=uuid.uuid4,
+        default=uuid_module.uuid4,
         nullable=False,
     )
     external_id: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -59,7 +58,7 @@ class Document(Base):
         String(20),
         nullable=False,
     )
-    source_id: Mapped[uuid.UUID] = mapped_column(
+    source_id: Mapped[uuid_module.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("external_sources.id"),
         nullable=False,
@@ -83,12 +82,12 @@ class ExternalSource(Base):
     """
 
     __tablename__ = "external_sources"
-    __table_args__: ClassVar[dict[str, str]] = {"schema": "assistant"}
+    __table_args__ = {"schema": "assistant"}  # noqa: RUF012
 
-    id: Mapped[uuid.UUID] = mapped_column(
+    id: Mapped[uuid_module.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
-        default=uuid.uuid4,
+        default=uuid_module.uuid4,
     )
     provider: Mapped[str] = mapped_column(String(100), nullable=False)
     provider_query: Mapped[str] = mapped_column(Text, nullable=True)


### PR DESCRIPTION
## Summary
- Make `make typecheck` / `make test` use venv-local binaries so they work without activating `.venv`.
- Fix strict mypy issues in adapters + SQLAlchemy models, and add a targeted mypy override for untyped `yaml` imports (no extra deps).

## Test plan
- [x] `make typecheck`
- [x] `make test`