### PR TITLE
feat: add FastAPI REST API for user, notebook, and note

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude has finished\" with title \"Claude Code\"'"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ assistant/
 **Python Version**: >= 3.13
 **Package Manager**: uv
 
+## Architecture
+
+The architecture of the system is described in [`Architecture`](docs/architecture/README.md)
+
 ## Quick Start
 
 > [!NOTE]
@@ -38,6 +42,18 @@ assistant/
 > See the instructions below to know how to setup the venv
 
 ### Setup Development Environment
+
+#### Start dev services
+
+We have a docker compose bundle for the db and other dev services
+
+```bash
+# Start the devservices and detach
+docker compose up -d
+
+# Stops the devservices
+docker compose down
+```
 
 #### Quick Setup (Recommended)
 
@@ -118,22 +134,6 @@ black src/
 
 Every time you apply a change, run tests and typechecking as described below.
 
-### Adding New Modules
-
-1. Create the module file in `src/assistant/`
-2. Add type hints to all functions and classes
-3. Create corresponding test file in `tests/`
-4. Document the module in `docs/modules/`
-5. Update `src/assistant/__init__.py` if exposing public API
-
-### Making Architecture Decisions
-
-1. Create a new ADR in `docs/adr/` following the template
-2. Discuss the decision, alternatives, and consequences
-3. Update the index in `docs/adr/README.md`
-4. Implement the decision
-5. Reference the ADR in relevant code comments
-
 ### Writing Tests
 
 - Place tests in `tests/` mirroring the `src/assistant/` structure
@@ -169,6 +169,50 @@ python -m assistant.cli.chat <thread_id>
 
 Exit with **Ctrl+Q**. See [`docs/modules/tui.md`](docs/modules/tui.md) for details.
 
+### REST API Server
+
+Start the API server (requires Postgres to be running, see below):
+
+```bash
+# Set up the database (first time only)
+python -m assistant.cli.setup_database
+
+# Start the server
+python -m assistant.cli.api_server
+```
+
+The server runs on `http://localhost:8000` by default. Options:
+- `--host` (default: 0.0.0.0)
+- `--port` (default: 8000)
+- `--reload` (auto-reload on code changes)
+
+OpenAPI docs are available at `http://localhost:8000/docs`.
+
+### API Client CLI
+
+A CLI client for manually calling the API:
+
+```bash
+# User operations
+python -m assistant.cli.api_client create-user --email user@example.com --firstname Jane --lastname Doe
+python -m assistant.cli.api_client get-user <uid>
+python -m assistant.cli.api_client update-user <uid> --firstname Updated
+
+# Notebook operations (--user-id required for create and list)
+python -m assistant.cli.api_client create-notebook --name "My Notebook" --user-id <uid>
+python -m assistant.cli.api_client list-notebooks --user-id <uid>
+python -m assistant.cli.api_client get-notebook <notebook_id>
+python -m assistant.cli.api_client delete-notebook <notebook_id>
+
+# Note operations
+python -m assistant.cli.api_client create-note --notebook-id <id> --title "My Note" --user-id <uid>
+python -m assistant.cli.api_client list-notes --notebook-id <id>
+python -m assistant.cli.api_client get-note --notebook-id <id> --note-id <id>
+python -m assistant.cli.api_client delete-note --notebook-id <id> --note-id <id>
+```
+
+Options: `--base-url` (default: http://localhost:8000), `--offset`, `--limit` for list commands.
+
 ### Development services (Postgres)
 
 When a task needs the Postgres database (e.g. running app code or tests that hit the DB), first ensure services are up by running `make services-up`. This is idempotent (no-op if the stack is already running). To stop the bundle when no longer needed, run `make services-down`.
@@ -198,3 +242,11 @@ pytest tests/test_specific.py::test_function_name
 4. Project-level: Update README.md
 
 ## Conventions
+
+### API Layer
+
+API route handlers must not mutate ORM entities directly. All data
+operations (create, read, update, delete) go through service functions in
+`src/assistant/notes/service.py` or `src/assistant/notes/user_service.py`.
+The service layer owns flush/transaction semantics; the API layer owns
+HTTP concerns (request parsing, response serialization, session commit).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -147,3 +147,4 @@ the webui.
 ## Subcomponents
 
 - [`Notes Service`](notesservice.md)
+- [`API`](api.md)

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -1,0 +1,239 @@
+# The API
+
+As described in [`Architecture`](../README.md), we have two APIs systems:
+
+- A rest API implemented with FastAPI
+- A websocket API to manage the push based interactions.
+
+All functionalities are supported with both APIs
+
+## Rest API
+
+The API is an OpenAPI implemented with FastAPI. It follows the REST principles.
+
+### Authentication
+
+We support two modes for authentication:
+
+- JWT Token + refresh token passed as Httponly cookies. This is for interactions
+  with the web UI
+
+- Oauth2 style access token + refresh token for direct API access and mobile apps.
+
+We will support two authentication mechanisms:
+
+- user name and password. Identities are stored in the DB
+
+- Google OAuth2 authentication
+
+All tokens are stored in the DB for now.
+
+**Current state**: Authentication is not yet implemented. The API uses an
+`X-User-Id` header to identify the acting user. Endpoints that need to
+know the current user (creating notebooks, listing notebooks, creating
+notes) require this header. It will be replaced by JWT-based auth.
+
+### User
+
+`POST /user`
+
+Create a user. Returns the created user with a generated UUID.
+
+Request body:
+```json
+{
+    "email": "user@example.com",
+    "firstname": "Jane",
+    "lastname": "Doe"
+}
+```
+
+Response (201):
+```json
+{
+    "uid": "uuid",
+    "email": "user@example.com",
+    "firstname": "Jane",
+    "lastname": "Doe"
+}
+```
+
+`GET /user/{uid}`
+
+Retrieve a user by UUID. Returns 404 if not found.
+
+`PATCH /user/{uid}`
+
+Partial update of a user. All fields are optional.
+
+Request body:
+```json
+{
+    "email": "new@example.com",
+    "firstname": "Updated"
+}
+```
+
+### Notebooks
+
+`POST /notebook`
+
+Create a notebook. Requires `X-User-Id` header.
+
+Request body:
+```json
+{
+    "name": "My Notebook"
+}
+```
+
+Response (201):
+```json
+{
+    "id": "uuid",
+    "name": "My Notebook",
+    "owner_id": "uuid"
+}
+```
+
+`GET /notebook`
+
+List notebooks for the current user. Requires `X-User-Id` header.
+Supports pagination via query parameters:
+- `offset` (default: 0)
+- `limit` (default: 20, max: 100)
+
+`GET /notebook/{id}`
+
+Retrieve a single notebook by UUID. Returns 404 if not found.
+
+`PATCH /notebook/{id}`
+
+Update a notebook. Currently only `name` can be updated.
+
+Request body:
+```json
+{
+    "name": "New Name"
+}
+```
+
+`DELETE /notebook/{id}`
+
+Delete a notebook and all its notes (cascade). Returns 204 on success,
+404 if not found.
+
+### Notes
+
+`POST /notebook/{notebook_id}/note`
+
+Create a note in a notebook. Requires `X-User-Id` header.
+When creating a note we do not provide the nodes.
+
+Request body:
+```json
+{
+    "title": "My Note"
+}
+```
+
+Response (201):
+```json
+{
+    "id": "uuid",
+    "notebook_id": "uuid",
+    "owner_id": "uuid",
+    "title": "My Note",
+    "creation_timestamp": "2026-01-01T00:00:00Z",
+    "update_timestamp": "2026-01-01T00:00:00Z"
+}
+```
+
+`GET /notebook/{notebook_id}/note`
+
+List notes in a notebook. Supports pagination via `offset` and `limit`
+query parameters.
+
+`GET /notebook/{notebook_id}/note/{note_id}`
+
+Retrieve a single note. The note must belong to the specified notebook,
+otherwise returns 404.
+
+`PATCH /notebook/{notebook_id}/note/{note_id}`
+
+Update a note. Currently only `title` can be updated. The note must
+belong to the specified notebook.
+
+Request body:
+```json
+{
+    "title": "Updated Title"
+}
+```
+
+`DELETE /notebook/{notebook_id}/note/{note_id}`
+
+Delete a note and all its nodes (cascade). The note must belong to
+the specified notebook. Returns 204 on success, 404 if not found.
+
+### Nodes
+
+The resource is `/notebook/.../note/.../node`
+We support the following operations:
+
+Add node with POST:
+```
+{
+    position: .... # This is the position of the previous node
+    payload: ....
+}
+```
+
+We pick the position of the previous node and insert the node between that
+position and the next at midpoint
+
+PATCH `/notebook/.../note/.../node/...`
+Splits a node
+{
+    offset: ... # The character at which to split
+}
+
+PUT `/notebook/.../note/.../node/...`
+Two options:
+Replace payload
+{
+    payload: ....
+}
+
+Merge nodes. The nodes have to be consecutive.
+{
+    nodes: [
+        node1,
+        node2,...
+    ]
+}
+
+DELETE `/notebook/.../note/.../node/...`
+Deletes a node.
+
+**Current state**: Node endpoints are not yet implemented. The service
+layer supports all node operations (add, insert, update, split, merge,
+delete) and will be exposed in a future iteration.
+
+### Error Responses
+
+All error responses follow the format:
+```json
+{
+    "detail": "Error message"
+}
+```
+
+Status codes:
+- 404: Resource not found
+- 409: Conflict (duplicate email, version conflict)
+- 422: Validation error (missing/invalid fields or headers)
+
+## Websocket
+
+TBD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,13 @@ dependencies = [
     "langchain_core>=1.2.16",
     "langchain-postgres>=0.0.17",
     "langsmith>=0.7.22",
-    "openevals>=0.1.3", 
+    "openevals>=0.1.3",
     "openai>=2.29.0",
     "python-dotenv>=1.2.1",
     "langgraph-checkpoint-postgres>=3.0.4",
     "textual>=8.0.2",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.32.0",
 ]
 
 [project.optional-dependencies]
@@ -35,6 +37,7 @@ dev = [
     "ruff>=0.1.6",
     "pre-commit>=3.5.0",
     "bandit[toml]>=1.7.5",
+    "httpx>=0.27.0",
 ]
 
 [build-system]
@@ -69,6 +72,10 @@ strict_concatenate = true
 
 [[tool.mypy.overrides]]
 module = ["yaml", "yaml.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["uvicorn", "uvicorn.*"]
 ignore_missing_imports = true
 
 [tool.ruff]
@@ -117,6 +124,7 @@ ignore = [
 "src/assistant/restore.py" = ["E402", "TC001", "TC002", "TC003"]
 "src/assistant/models/content.py" = ["E402", "TC001", "TC002", "TC003"]
 "src/assistant/models/database.py" = ["PLC0415"]
+"src/assistant/api/**/*.py" = ["B008", "TC001", "TC002", "TC003"]
 
 [tool.pyright]
 extraPaths = ["src"]

--- a/src/assistant/api/__init__.py
+++ b/src/assistant/api/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI REST API for the assistant package."""
+
+from assistant.api.app import create_app
+
+__all__ = ["create_app"]

--- a/src/assistant/api/app.py
+++ b/src/assistant/api/app.py
@@ -1,0 +1,35 @@
+"""FastAPI application factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI
+
+from assistant.api.exceptions import register_exception_handlers
+from assistant.api.routes.notebooks import router as notebooks_router
+from assistant.api.routes.notes import router as notes_router
+from assistant.api.routes.users import router as users_router
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+def create_app(
+    session_factory: sessionmaker[Session] | None = None,
+) -> FastAPI:
+    app = FastAPI(title="Assistant API", version="0.1.0")
+
+    if session_factory is None:
+        from assistant.models.database import get_session_factory
+
+        session_factory = get_session_factory()
+    app.state.session_factory = session_factory
+
+    register_exception_handlers(app)
+
+    app.include_router(users_router, prefix="/user", tags=["users"])
+    app.include_router(notebooks_router, prefix="/notebook", tags=["notebooks"])
+    app.include_router(notes_router, prefix="/notebook", tags=["notes"])
+
+    return app

--- a/src/assistant/api/dependencies.py
+++ b/src/assistant/api/dependencies.py
@@ -1,0 +1,43 @@
+"""Shared FastAPI dependencies."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, Request
+from sqlalchemy.orm import Session
+
+
+def get_session(
+    request: Request,
+) -> Generator[Session]:
+    session_factory = request.app.state.session_factory
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# TODO: return User entity instead of UUID when JWT auth is implemented,
+# so we validate existence and load user data in one step.
+def get_current_user_id(
+    x_user_id: Annotated[str, Header()],
+) -> uuid.UUID:
+    try:
+        return uuid.UUID(x_user_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid X-User-Id header",
+        ) from exc
+
+
+SessionDep = Annotated[Session, Depends(get_session)]
+CurrentUserId = Annotated[uuid.UUID, Depends(get_current_user_id)]

--- a/src/assistant/api/exceptions.py
+++ b/src/assistant/api/exceptions.py
@@ -1,0 +1,53 @@
+"""Exception-to-HTTP-response mapping."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import IntegrityError
+
+from assistant.notes.exceptions import (
+    NodeVersionConflictError,
+    NotesServiceError,
+    UserNotFoundError,
+)
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI, Request
+
+logger = logging.getLogger(__name__)
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(UserNotFoundError)
+    async def user_not_found_handler(
+        request: Request,  # noqa: ARG001
+        exc: UserNotFoundError,
+    ) -> JSONResponse:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(NodeVersionConflictError)
+    async def version_conflict_handler(
+        request: Request,  # noqa: ARG001
+        exc: NodeVersionConflictError,
+    ) -> JSONResponse:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    @app.exception_handler(IntegrityError)
+    async def integrity_error_handler(
+        request: Request,  # noqa: ARG001
+        exc: IntegrityError,  # noqa: ARG001
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "Conflict: duplicate or constraint violation"},
+        )
+
+    @app.exception_handler(NotesServiceError)
+    async def notes_service_error_handler(
+        request: Request,  # noqa: ARG001
+        exc: NotesServiceError,
+    ) -> JSONResponse:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})

--- a/src/assistant/api/routes/__init__.py
+++ b/src/assistant/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules."""

--- a/src/assistant/api/routes/notebooks.py
+++ b/src/assistant/api/routes/notebooks.py
@@ -1,0 +1,77 @@
+"""Notebook API routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Response
+
+from assistant.api.dependencies import CurrentUserId, SessionDep
+from assistant.api.schemas.notebooks import (
+    NotebookCreate,
+    NotebookResponse,
+    NotebookUpdate,
+)
+from assistant.api.schemas.pagination import Pagination
+from assistant.notes.service import (
+    create_notebook,
+    delete_notebook,
+    get_notebook,
+    list_notebooks,
+    update_notebook,
+)
+
+router = APIRouter()
+
+
+@router.post("", status_code=201, response_model=NotebookResponse)
+def create_notebook_endpoint(
+    body: NotebookCreate,
+    session: SessionDep,
+    user_id: CurrentUserId,
+) -> NotebookResponse:
+    notebook = create_notebook(session, name=body.name, owner_id=user_id)
+    return NotebookResponse.model_validate(notebook)
+
+
+@router.get("", response_model=list[NotebookResponse])
+def list_notebooks_endpoint(
+    session: SessionDep,
+    user_id: CurrentUserId,
+    pagination: Pagination,
+) -> list[NotebookResponse]:
+    notebooks = list_notebooks(
+        session,
+        owner_id=user_id,
+        offset=pagination.offset,
+        limit=pagination.limit,
+    )
+    return [NotebookResponse.model_validate(nb) for nb in notebooks]
+
+
+@router.get("/{notebook_id}", response_model=NotebookResponse)
+def get_notebook_endpoint(
+    notebook_id: uuid.UUID,
+    session: SessionDep,
+) -> NotebookResponse:
+    notebook = get_notebook(session, notebook_id)
+    return NotebookResponse.model_validate(notebook)
+
+
+@router.patch("/{notebook_id}", response_model=NotebookResponse)
+def update_notebook_endpoint(
+    notebook_id: uuid.UUID,
+    body: NotebookUpdate,
+    session: SessionDep,
+) -> NotebookResponse:
+    notebook = update_notebook(session, notebook_id, name=body.name)
+    return NotebookResponse.model_validate(notebook)
+
+
+@router.delete("/{notebook_id}", status_code=204)
+def delete_notebook_endpoint(
+    notebook_id: uuid.UUID,
+    session: SessionDep,
+) -> Response:
+    delete_notebook(session, notebook_id)
+    return Response(status_code=204)

--- a/src/assistant/api/routes/notes.py
+++ b/src/assistant/api/routes/notes.py
@@ -1,0 +1,113 @@
+"""Note API routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Response
+
+from assistant.api.dependencies import CurrentUserId, SessionDep
+from assistant.api.schemas.notes import NoteCreate, NoteResponse, NoteUpdate
+from assistant.api.schemas.pagination import Pagination
+from assistant.models.schema import Note
+from assistant.notes.exceptions import NoteNotFoundError
+from assistant.notes.service import (
+    create_note,
+    delete_note,
+    get_note,
+    list_notes,
+    update_note,
+)
+
+router = APIRouter()
+
+
+def _get_note_in_notebook(
+    session: SessionDep,
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+) -> Note:
+    note = get_note(session, note_id)
+    if note.notebook_id != notebook_id:
+        raise NoteNotFoundError(str(note_id))
+    return note
+
+
+@router.post(
+    "/{notebook_id}/note",
+    status_code=201,
+    response_model=NoteResponse,
+)
+def create_note_endpoint(
+    notebook_id: uuid.UUID,
+    body: NoteCreate,
+    session: SessionDep,
+    user_id: CurrentUserId,
+) -> NoteResponse:
+    note = create_note(
+        session,
+        notebook_id=notebook_id,
+        owner_id=user_id,
+        title=body.title,
+    )
+    return NoteResponse.model_validate(note)
+
+
+@router.get(
+    "/{notebook_id}/note",
+    response_model=list[NoteResponse],
+)
+def list_notes_endpoint(
+    notebook_id: uuid.UUID,
+    session: SessionDep,
+    pagination: Pagination,
+) -> list[NoteResponse]:
+    notes = list_notes(
+        session,
+        notebook_id=notebook_id,
+        offset=pagination.offset,
+        limit=pagination.limit,
+    )
+    return [NoteResponse.model_validate(n) for n in notes]
+
+
+@router.get(
+    "/{notebook_id}/note/{note_id}",
+    response_model=NoteResponse,
+)
+def get_note_endpoint(
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+    session: SessionDep,
+) -> NoteResponse:
+    note = _get_note_in_notebook(session, notebook_id, note_id)
+    return NoteResponse.model_validate(note)
+
+
+@router.patch(
+    "/{notebook_id}/note/{note_id}",
+    response_model=NoteResponse,
+)
+def update_note_endpoint(
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+    body: NoteUpdate,
+    session: SessionDep,
+) -> NoteResponse:
+    _get_note_in_notebook(session, notebook_id, note_id)
+    note = update_note(session, note_id, title=body.title)
+    return NoteResponse.model_validate(note)
+
+
+@router.delete(
+    "/{notebook_id}/note/{note_id}",
+    status_code=204,
+)
+def delete_note_endpoint(
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+    session: SessionDep,
+) -> Response:
+    _get_note_in_notebook(session, notebook_id, note_id)
+    delete_note(session, note_id)
+    return Response(status_code=204)

--- a/src/assistant/api/routes/users.py
+++ b/src/assistant/api/routes/users.py
@@ -1,0 +1,52 @@
+"""User API routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter
+
+from assistant.api.dependencies import SessionDep
+from assistant.api.schemas.users import UserCreate, UserResponse, UserUpdate
+from assistant.notes.user_service import create_user, get_user, update_user
+
+router = APIRouter()
+
+
+@router.post("", status_code=201, response_model=UserResponse)
+def create_user_endpoint(
+    body: UserCreate,
+    session: SessionDep,
+) -> UserResponse:
+    user = create_user(
+        session,
+        email=body.email,
+        firstname=body.firstname,
+        lastname=body.lastname,
+    )
+    return UserResponse.model_validate(user)
+
+
+@router.get("/{uid}", response_model=UserResponse)
+def get_user_endpoint(
+    uid: uuid.UUID,
+    session: SessionDep,
+) -> UserResponse:
+    user = get_user(session, uid)
+    return UserResponse.model_validate(user)
+
+
+@router.patch("/{uid}", response_model=UserResponse)
+def update_user_endpoint(
+    uid: uuid.UUID,
+    body: UserUpdate,
+    session: SessionDep,
+) -> UserResponse:
+    user = update_user(
+        session,
+        uid,
+        email=body.email,
+        firstname=body.firstname,
+        lastname=body.lastname,
+    )
+    return UserResponse.model_validate(user)

--- a/src/assistant/api/schemas/__init__.py
+++ b/src/assistant/api/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic schemas for API request/response models."""

--- a/src/assistant/api/schemas/notebooks.py
+++ b/src/assistant/api/schemas/notebooks.py
@@ -1,0 +1,23 @@
+"""Pydantic schemas for Notebook endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NotebookCreate(BaseModel):
+    name: str
+
+
+class NotebookUpdate(BaseModel):
+    name: str | None = None
+
+
+class NotebookResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    owner_id: uuid.UUID

--- a/src/assistant/api/schemas/notes.py
+++ b/src/assistant/api/schemas/notes.py
@@ -1,0 +1,27 @@
+"""Pydantic schemas for Note endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NoteCreate(BaseModel):
+    title: str
+
+
+class NoteUpdate(BaseModel):
+    title: str | None = None
+
+
+class NoteResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    notebook_id: uuid.UUID
+    owner_id: uuid.UUID
+    title: str
+    creation_timestamp: datetime
+    update_timestamp: datetime

--- a/src/assistant/api/schemas/pagination.py
+++ b/src/assistant/api/schemas/pagination.py
@@ -1,0 +1,24 @@
+"""Shared pagination parameters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import Depends, Query
+
+
+@dataclass(frozen=True)
+class PaginationParams:
+    offset: int
+    limit: int
+
+
+def pagination_params(
+    offset: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> PaginationParams:
+    return PaginationParams(offset=offset, limit=limit)
+
+
+Pagination = Annotated[PaginationParams, Depends(pagination_params)]

--- a/src/assistant/api/schemas/users.py
+++ b/src/assistant/api/schemas/users.py
@@ -1,0 +1,28 @@
+"""Pydantic schemas for User endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UserCreate(BaseModel):
+    email: str
+    firstname: str
+    lastname: str
+
+
+class UserUpdate(BaseModel):
+    email: str | None = None
+    firstname: str | None = None
+    lastname: str | None = None
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    uid: uuid.UUID
+    email: str
+    firstname: str
+    lastname: str

--- a/src/assistant/cli/api_client.py
+++ b/src/assistant/cli/api_client.py
@@ -1,0 +1,212 @@
+"""Simple CLI client for the Assistant REST API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+DEFAULT_BASE_URL = "http://localhost:8000"
+_NO_CONTENT = 204
+
+
+def _print_response(response: httpx.Response) -> None:
+    if response.status_code == _NO_CONTENT:
+        print(f"Status: {response.status_code} No Content")  # noqa: T201
+        return
+    print(f"Status: {response.status_code}")  # noqa: T201
+    try:
+        print(json.dumps(response.json(), indent=2))  # noqa: T201
+    except Exception:
+        print(response.text)  # noqa: T201
+
+
+def cmd_create_user(args: argparse.Namespace) -> None:
+    response = httpx.post(
+        f"{args.base_url}/user",
+        json={
+            "email": args.email,
+            "firstname": args.firstname,
+            "lastname": args.lastname,
+        },
+    )
+    _print_response(response)
+
+
+def cmd_get_user(args: argparse.Namespace) -> None:
+    response = httpx.get(f"{args.base_url}/user/{args.uid}")
+    _print_response(response)
+
+
+def cmd_update_user(args: argparse.Namespace) -> None:
+    body: dict[str, str] = {}
+    if args.email:
+        body["email"] = args.email
+    if args.firstname:
+        body["firstname"] = args.firstname
+    if args.lastname:
+        body["lastname"] = args.lastname
+    response = httpx.patch(
+        f"{args.base_url}/user/{args.uid}",
+        json=body,
+    )
+    _print_response(response)
+
+
+def cmd_create_notebook(args: argparse.Namespace) -> None:
+    response = httpx.post(
+        f"{args.base_url}/notebook",
+        json={"name": args.name},
+        headers={"X-User-Id": args.user_id},
+    )
+    _print_response(response)
+
+
+def cmd_list_notebooks(args: argparse.Namespace) -> None:
+    response = httpx.get(
+        f"{args.base_url}/notebook",
+        headers={"X-User-Id": args.user_id},
+        params={"offset": args.offset, "limit": args.limit},
+    )
+    _print_response(response)
+
+
+def cmd_get_notebook(args: argparse.Namespace) -> None:
+    response = httpx.get(
+        f"{args.base_url}/notebook/{args.notebook_id}",
+    )
+    _print_response(response)
+
+
+def cmd_delete_notebook(args: argparse.Namespace) -> None:
+    response = httpx.delete(
+        f"{args.base_url}/notebook/{args.notebook_id}",
+    )
+    _print_response(response)
+
+
+def cmd_create_note(args: argparse.Namespace) -> None:
+    response = httpx.post(
+        f"{args.base_url}/notebook/{args.notebook_id}/note",
+        json={"title": args.title},
+        headers={"X-User-Id": args.user_id},
+    )
+    _print_response(response)
+
+
+def cmd_list_notes(args: argparse.Namespace) -> None:
+    response = httpx.get(
+        f"{args.base_url}/notebook/{args.notebook_id}/note",
+        params={"offset": args.offset, "limit": args.limit},
+    )
+    _print_response(response)
+
+
+def cmd_get_note(args: argparse.Namespace) -> None:
+    response = httpx.get(
+        f"{args.base_url}/notebook/{args.notebook_id}/note/{args.note_id}",
+    )
+    _print_response(response)
+
+
+def cmd_delete_note(args: argparse.Namespace) -> None:
+    response = httpx.delete(
+        f"{args.base_url}/notebook/{args.notebook_id}/note/{args.note_id}",
+    )
+    _print_response(response)
+
+
+def _register_user_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    p = subparsers.add_parser("create-user")
+    p.add_argument("--email", required=True)
+    p.add_argument("--firstname", required=True)
+    p.add_argument("--lastname", required=True)
+    p.set_defaults(func=cmd_create_user)
+
+    p = subparsers.add_parser("get-user")
+    p.add_argument("uid")
+    p.set_defaults(func=cmd_get_user)
+
+    p = subparsers.add_parser("update-user")
+    p.add_argument("uid")
+    p.add_argument("--email")
+    p.add_argument("--firstname")
+    p.add_argument("--lastname")
+    p.set_defaults(func=cmd_update_user)
+
+
+def _register_notebook_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    p = subparsers.add_parser("create-notebook")
+    p.add_argument("--name", required=True)
+    p.add_argument("--user-id", required=True)
+    p.set_defaults(func=cmd_create_notebook)
+
+    p = subparsers.add_parser("list-notebooks")
+    p.add_argument("--user-id", required=True)
+    p.add_argument("--offset", type=int, default=0)
+    p.add_argument("--limit", type=int, default=20)
+    p.set_defaults(func=cmd_list_notebooks)
+
+    p = subparsers.add_parser("get-notebook")
+    p.add_argument("notebook_id")
+    p.set_defaults(func=cmd_get_notebook)
+
+    p = subparsers.add_parser("delete-notebook")
+    p.add_argument("notebook_id")
+    p.set_defaults(func=cmd_delete_notebook)
+
+
+def _register_note_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    p = subparsers.add_parser("create-note")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--title", required=True)
+    p.add_argument("--user-id", required=True)
+    p.set_defaults(func=cmd_create_note)
+
+    p = subparsers.add_parser("list-notes")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--offset", type=int, default=0)
+    p.add_argument("--limit", type=int, default=20)
+    p.set_defaults(func=cmd_list_notes)
+
+    p = subparsers.add_parser("get-note")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--note-id", required=True)
+    p.set_defaults(func=cmd_get_note)
+
+    p = subparsers.add_parser("delete-note")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--note-id", required=True)
+    p.set_defaults(func=cmd_delete_note)
+
+
+def main() -> int:
+    """Run the API client CLI."""
+    parser = argparse.ArgumentParser(
+        description="Assistant API client",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help=f"API base URL (default: {DEFAULT_BASE_URL})",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _register_user_commands(subparsers)
+    _register_notebook_commands(subparsers)
+    _register_note_commands(subparsers)
+
+    args = parser.parse_args()
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/assistant/cli/api_server.py
+++ b/src/assistant/cli/api_server.py
@@ -1,0 +1,57 @@
+"""CLI entry point for the Assistant API server."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    """Run the Assistant API server."""
+    parser = argparse.ArgumentParser(
+        description="Run the Assistant API server",
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Bind host (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Bind port (default: 8000)",
+    )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable auto-reload",
+    )
+    args = parser.parse_args()
+
+    import uvicorn
+
+    logger.info(
+        "Starting API server on %s:%d",
+        args.host,
+        args.port,
+    )
+    uvicorn.run(
+        "assistant.api.app:create_app",
+        factory=True,
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/assistant/notes/exceptions.py
+++ b/src/assistant/notes/exceptions.py
@@ -12,6 +12,10 @@ class NotesServiceError(Exception):
     """Base exception for the notes service."""
 
 
+class UserNotFoundError(NotesServiceError):
+    """Raised when a user is not found."""
+
+
 class NotebookNotFoundError(NotesServiceError):
     """Raised when a notebook is not found."""
 

--- a/src/assistant/notes/service.py
+++ b/src/assistant/notes/service.py
@@ -119,9 +119,27 @@ def get_notebook(
 def list_notebooks(
     session: Session,
     owner_id: uuid.UUID,
+    *,
+    offset: int = 0,
+    limit: int | None = None,
 ) -> list[Notebook]:
-    stmt = select(Notebook).where(Notebook.owner_id == owner_id)
+    stmt = select(Notebook).where(Notebook.owner_id == owner_id).offset(offset)
+    if limit is not None:
+        stmt = stmt.limit(limit)
     return list(session.scalars(stmt))
+
+
+def update_notebook(
+    session: Session,
+    notebook_id: uuid.UUID,
+    *,
+    name: str | None = None,
+) -> Notebook:
+    notebook = get_notebook(session, notebook_id)
+    if name is not None:
+        notebook.name = name
+    session.flush()
+    return notebook
 
 
 def delete_notebook(
@@ -168,9 +186,28 @@ def get_note(
 def list_notes(
     session: Session,
     notebook_id: uuid.UUID,
+    *,
+    offset: int = 0,
+    limit: int | None = None,
 ) -> list[Note]:
-    stmt = select(Note).where(Note.notebook_id == notebook_id)
+    stmt = select(Note).where(Note.notebook_id == notebook_id).offset(offset)
+    if limit is not None:
+        stmt = stmt.limit(limit)
     return list(session.scalars(stmt))
+
+
+def update_note(
+    session: Session,
+    note_id: uuid.UUID,
+    *,
+    title: str | None = None,
+) -> Note:
+    note = get_note(session, note_id)
+    if title is not None:
+        note.title = title
+    _touch_note(session, note_id)
+    session.flush()
+    return note
 
 
 def delete_note(

--- a/src/assistant/notes/user_service.py
+++ b/src/assistant/notes/user_service.py
@@ -1,0 +1,54 @@
+"""User service — User CRUD operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from assistant.models.schema import User
+from assistant.notes.exceptions import UserNotFoundError
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.orm import Session
+
+
+def create_user(
+    session: Session,
+    email: str,
+    firstname: str,
+    lastname: str,
+) -> User:
+    user = User(email=email, firstname=firstname, lastname=lastname)
+    session.add(user)
+    session.flush()
+    return user
+
+
+def get_user(
+    session: Session,
+    uid: uuid.UUID,
+) -> User:
+    user = session.get(User, uid)
+    if user is None:
+        raise UserNotFoundError(str(uid))
+    return user
+
+
+def update_user(
+    session: Session,
+    uid: uuid.UUID,
+    *,
+    email: str | None = None,
+    firstname: str | None = None,
+    lastname: str | None = None,
+) -> User:
+    user = get_user(session, uid)
+    if email is not None:
+        user.email = email
+    if firstname is not None:
+        user.firstname = firstname
+    if lastname is not None:
+        user.lastname = lastname
+    session.flush()
+    return user

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""API test package."""

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,116 @@
+"""API test fixtures."""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from assistant.api.app import create_app
+from assistant.api.dependencies import get_session
+from assistant.models import schema as _schema  # noqa: F401
+from assistant.models.database import Base
+from assistant.models.schema import User
+
+
+@pytest.fixture(scope="module")
+def _api_engine():  # noqa: ANN202
+    """Module-scoped engine with schema stripping for SQLite."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    tables = Base.metadata.sorted_tables
+    original_schemas: dict[str, str | None] = {}
+
+    for table in tables:
+        original_schemas[table.fullname] = table.schema
+        table.schema = None
+
+    for table in tables:
+        for col in table.columns:
+            for fk in col.foreign_keys:
+                fk._table_key = None  # type: ignore[attr-defined]
+                ref_table_name = fk.column.table.name
+                ref_col_name = fk.column.name
+                ref_table = Base.metadata.tables.get(ref_table_name)
+                if ref_table is not None:
+                    fk.column = ref_table.columns[ref_col_name]  # type: ignore[assignment]
+
+    Base.metadata.create_all(engine)
+
+    yield engine
+
+    Base.metadata.drop_all(engine)
+    engine.dispose()
+
+    for table in tables:
+        table.schema = original_schemas[table.fullname]
+
+
+@pytest.fixture
+def db_session(
+    _api_engine,  # noqa: ANN001
+) -> Iterator[Session]:
+    """Per-test session that rolls back after each test."""
+    connection = _api_engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+
+    # Start a savepoint so nested session.begin() calls work
+    nested = connection.begin_nested()
+
+    @event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(
+        sess: Session,  # noqa: ARG001
+        trans,  # noqa: ANN001
+    ) -> None:
+        nonlocal nested
+        if trans.nested and not trans._parent.nested:  # type: ignore[attr-defined]
+            nested = connection.begin_nested()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture
+def client(db_session: Session) -> Iterator[TestClient]:
+    def override_get_session() -> Generator[Session]:
+        try:
+            yield db_session
+        except Exception:
+            db_session.rollback()
+            raise
+
+    app = create_app()
+    app.dependency_overrides[get_session] = override_get_session
+    with TestClient(app) as tc:
+        yield tc
+
+
+@pytest.fixture
+def test_user(db_session: Session) -> User:
+    user = User(
+        email="test@example.com",
+        firstname="Test",
+        lastname="User",
+    )
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+@pytest.fixture
+def auth_headers(test_user: User) -> dict[str, str]:
+    return {"X-User-Id": str(test_user.uid)}

--- a/tests/api/test_notebooks.py
+++ b/tests/api/test_notebooks.py
@@ -1,0 +1,153 @@
+"""Tests for Notebook API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from assistant.models.schema import User as UserModel
+from assistant.notes.service import create_notebook
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+    from assistant.models.schema import User
+
+
+class TestCreateNotebook:
+    def test_create_notebook(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        response = client.post(
+            "/notebook",
+            json={"name": "My Notebook"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "My Notebook"
+        assert "id" in data
+
+    def test_create_notebook_missing_header(
+        self,
+        client: TestClient,
+    ) -> None:
+        response = client.post(
+            "/notebook",
+            json={"name": "My Notebook"},
+        )
+        assert response.status_code == 422
+
+
+class TestListNotebooks:
+    def test_list_notebooks(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        create_notebook(db_session, "NB1", test_user.uid)
+        create_notebook(db_session, "NB2", test_user.uid)
+
+        response = client.get("/notebook", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+    def test_list_notebooks_pagination(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        for i in range(5):
+            create_notebook(db_session, f"NB{i}", test_user.uid)
+
+        response = client.get(
+            "/notebook",
+            headers=auth_headers,
+            params={"offset": 0, "limit": 2},
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 2
+
+    def test_list_notebooks_only_own(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        other = UserModel(
+            email="other@test.com",
+            firstname="Other",
+            lastname="User",
+        )
+        db_session.add(other)
+        db_session.flush()
+
+        create_notebook(db_session, "Mine", test_user.uid)
+        create_notebook(db_session, "Theirs", other.uid)
+
+        response = client.get(
+            "/notebook",
+            headers={"X-User-Id": str(test_user.uid)},
+        )
+        assert len(response.json()) == 1
+        assert response.json()[0]["name"] == "Mine"
+
+
+class TestGetNotebook:
+    def test_get_notebook(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "Test NB", test_user.uid)
+        response = client.get(f"/notebook/{nb.id}")
+        assert response.status_code == 200
+        assert response.json()["name"] == "Test NB"
+
+    def test_get_notebook_not_found(self, client: TestClient) -> None:
+        response = client.get(f"/notebook/{uuid.uuid4()}")
+        assert response.status_code == 404
+
+
+class TestUpdateNotebook:
+    def test_update_notebook(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "Old Name", test_user.uid)
+        response = client.patch(
+            f"/notebook/{nb.id}",
+            json={"name": "New Name"},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "New Name"
+
+
+class TestDeleteNotebook:
+    def test_delete_notebook(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "To Delete", test_user.uid)
+        response = client.delete(f"/notebook/{nb.id}")
+        assert response.status_code == 204
+
+        response = client.get(f"/notebook/{nb.id}")
+        assert response.status_code == 404
+
+    def test_delete_notebook_not_found(self, client: TestClient) -> None:
+        response = client.delete(f"/notebook/{uuid.uuid4()}")
+        assert response.status_code == 404

--- a/tests/api/test_notes.py
+++ b/tests/api/test_notes.py
@@ -1,0 +1,186 @@
+"""Tests for Note API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from assistant.notes.service import create_note, create_notebook
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+    from assistant.models.schema import User
+
+
+class TestCreateNote:
+    def test_create_note(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "NB", test_user.uid)
+        response = client.post(
+            f"/notebook/{nb.id}/note",
+            json={"title": "My Note"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "My Note"
+        assert data["notebook_id"] == str(nb.id)
+
+    def test_create_note_missing_header(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "NB", test_user.uid)
+        response = client.post(
+            f"/notebook/{nb.id}/note",
+            json={"title": "My Note"},
+        )
+        assert response.status_code == 422
+
+
+class TestListNotes:
+    def test_list_notes(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "NB", test_user.uid)
+        create_note(db_session, nb.id, test_user.uid, "Note1")
+        create_note(db_session, nb.id, test_user.uid, "Note2")
+
+        response = client.get(f"/notebook/{nb.id}/note")
+        assert response.status_code == 200
+        assert len(response.json()) == 2
+
+    def test_list_notes_pagination(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "NB", test_user.uid)
+        for i in range(5):
+            create_note(db_session, nb.id, test_user.uid, f"Note{i}")
+
+        response = client.get(
+            f"/notebook/{nb.id}/note",
+            params={"offset": 0, "limit": 3},
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 3
+
+
+class TestGetNote:
+    def test_get_note(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "NB", test_user.uid)
+        note = create_note(db_session, nb.id, test_user.uid, "Test")
+
+        response = client.get(f"/notebook/{nb.id}/note/{note.id}")
+        assert response.status_code == 200
+        assert response.json()["title"] == "Test"
+
+    def test_get_note_wrong_notebook(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb1 = create_notebook(db_session, "NB1", test_user.uid)
+        nb2 = create_notebook(db_session, "NB2", test_user.uid)
+        note = create_note(db_session, nb1.id, test_user.uid, "Test")
+
+        response = client.get(f"/notebook/{nb2.id}/note/{note.id}")
+        assert response.status_code == 404
+
+    def test_get_note_not_found(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "NB", test_user.uid)
+        response = client.get(f"/notebook/{nb.id}/note/{uuid.uuid4()}")
+        assert response.status_code == 404
+
+
+class TestUpdateNote:
+    def test_update_note(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "NB", test_user.uid)
+        note = create_note(db_session, nb.id, test_user.uid, "Old")
+
+        response = client.patch(
+            f"/notebook/{nb.id}/note/{note.id}",
+            json={"title": "New"},
+        )
+        assert response.status_code == 200
+        assert response.json()["title"] == "New"
+
+    def test_update_note_wrong_notebook(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb1 = create_notebook(db_session, "NB1", test_user.uid)
+        nb2 = create_notebook(db_session, "NB2", test_user.uid)
+        note = create_note(db_session, nb1.id, test_user.uid, "Test")
+
+        response = client.patch(
+            f"/notebook/{nb2.id}/note/{note.id}",
+            json={"title": "Sneaky"},
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteNote:
+    def test_delete_note(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb = create_notebook(db_session, "NB", test_user.uid)
+        note = create_note(db_session, nb.id, test_user.uid, "Test")
+
+        response = client.delete(
+            f"/notebook/{nb.id}/note/{note.id}",
+        )
+        assert response.status_code == 204
+
+        response = client.get(f"/notebook/{nb.id}/note/{note.id}")
+        assert response.status_code == 404
+
+    def test_delete_note_wrong_notebook(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        nb1 = create_notebook(db_session, "NB1", test_user.uid)
+        nb2 = create_notebook(db_session, "NB2", test_user.uid)
+        note = create_note(db_session, nb1.id, test_user.uid, "Test")
+
+        response = client.delete(
+            f"/notebook/{nb2.id}/note/{note.id}",
+        )
+        assert response.status_code == 404

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -1,0 +1,119 @@
+"""Tests for User API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from assistant.models.schema import User as UserModel
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+    from assistant.models.schema import User
+
+
+class TestCreateUser:
+    def test_create_user(self, client: TestClient) -> None:
+        response = client.post(
+            "/user",
+            json={
+                "email": "new@example.com",
+                "firstname": "New",
+                "lastname": "User",
+            },
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["email"] == "new@example.com"
+        assert data["firstname"] == "New"
+        assert data["lastname"] == "User"
+        assert "uid" in data
+
+    def test_create_user_duplicate_email(
+        self,
+        client: TestClient,
+        test_user: User,  # noqa: ARG002
+    ) -> None:
+        response = client.post(
+            "/user",
+            json={
+                "email": "test@example.com",
+                "firstname": "Dup",
+                "lastname": "User",
+            },
+        )
+        assert response.status_code == 409
+
+
+class TestGetUser:
+    def test_get_user(
+        self,
+        client: TestClient,
+        test_user: User,
+    ) -> None:
+        response = client.get(f"/user/{test_user.uid}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["email"] == "test@example.com"
+        assert data["uid"] == str(test_user.uid)
+
+    def test_get_user_not_found(self, client: TestClient) -> None:
+        response = client.get(f"/user/{uuid.uuid4()}")
+        assert response.status_code == 404
+
+
+class TestUpdateUser:
+    def test_update_user_partial(
+        self,
+        client: TestClient,
+        test_user: User,
+    ) -> None:
+        response = client.patch(
+            f"/user/{test_user.uid}",
+            json={"firstname": "Updated"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["firstname"] == "Updated"
+        assert data["lastname"] == "User"
+
+    def test_update_user_not_found(self, client: TestClient) -> None:
+        response = client.patch(
+            f"/user/{uuid.uuid4()}",
+            json={"firstname": "Ghost"},
+        )
+        assert response.status_code == 404
+
+    def test_update_user_no_changes(
+        self,
+        client: TestClient,
+        test_user: User,
+    ) -> None:
+        response = client.patch(
+            f"/user/{test_user.uid}",
+            json={},
+        )
+        assert response.status_code == 200
+        assert response.json()["email"] == "test@example.com"
+
+    def test_update_user_duplicate_email(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        other = UserModel(
+            email="other@example.com",
+            firstname="Other",
+            lastname="User",
+        )
+        db_session.add(other)
+        db_session.flush()
+
+        response = client.patch(
+            f"/user/{test_user.uid}",
+            json={"email": "other@example.com"},
+        )
+        assert response.status_code == 409


### PR DESCRIPTION
## Summary
- Add FastAPI REST API with 13 endpoints for User, Notebook, and Note CRUD operations
- Add Pydantic request/response schemas, session management dependency, and exception-to-HTTP mapping
- Add `update_notebook` and `update_note` service functions to keep all data mutations in the service layer
- Add `user_service.py` with User CRUD following the existing service pattern
- Add CLI scripts: `api_server.py` (uvicorn launcher) and `api_client.py` (manual API testing)
- Add 29 API tests with FastAPI TestClient and SQLite fixtures
- Update `docs/architecture/api.md` with full endpoint documentation
- Update `AGENTS.md` with server/client usage and API layer convention

## Test plan
- [ ] `pytest tests/api/` — all 29 API tests pass
- [ ] `pytest tests/notes/` — existing service tests unaffected
- [ ] `ruff check src/assistant/api/` — clean
- [ ] `mypy src/assistant/api/` — clean
- [ ] Start server (`python -m assistant.cli.api_server`), create user and notebook via CLI client

🤖 Generated with [Claude Code](https://claude.com/claude-code)