### PR TITLE
feat: add Node REST API endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,18 +7,31 @@
 ```
 assistant/
 ├── src/
-│   └── assistant/          # Main package
-│       └── __init__.py
-├── tests/                  # Test suite
-├── docs/                   # Documentation
-│   ├── architecture/       # System architecture
-│   ├── adr/               # Architecture Decision Records
-│   ├── modules/           # Module documentation
-│   └── agents/            # AI agent guidelines
-├── .cursorrules           # Cursor AI configuration
-├── .claude/               # Claude AI configuration
-├── pyproject.toml         # Project configuration
-└── README.md              # This file
+│   └── assistant/              # Main package
+│       ├── adapters/           # Data source adapters & plugin system
+│       │   └── plugins/        # Adapter plugins (e.g. fake for testing)
+│       ├── agents/             # RAG agent, vector search, infra
+│       ├── api/                # FastAPI REST API
+│       │   ├── routes/         # Route handlers (users, notebooks, notes)
+│       │   └── schemas/        # Pydantic request/response schemas
+│       ├── cli/                # CLI entry points (server, client, db tools, chat)
+│       ├── data/               # Static data assets
+│       │   └── documents/
+│       ├── evals/              # Evaluation framework
+│       ├── models/             # SQLAlchemy ORM models & DB schema
+│       ├── notes/              # Notes service layer (CRUD, positions, users)
+│       └── tui/                # Terminal UI (Textual chat app)
+├── tests/                      # Test suite (mirrors src/ structure)
+├── docs/                       # Documentation
+│   ├── architecture/           # System architecture
+│   ├── adr/                    # Architecture Decision Records
+│   └── modules/                # Module documentation
+├── .claude/                    # Claude AI configuration
+├── .cursorrules                # Cursor AI configuration
+├── docker-compose.yml          # Dev services (Postgres)
+├── Makefile                    # Build & dev commands
+├── pyproject.toml              # Project configuration
+└── README.md
 ```
 
 # Working with This Codebase
@@ -138,7 +151,8 @@ Every time you apply a change, run tests and typechecking as described below.
 
 - Place tests in `tests/` mirroring the `src/assistant/` structure
 - Use `test_` prefix for test files and functions
-- Use `Test` prefix for test classes
+- Write tests as **module-level functions**, not methods inside classes
+- Group related tests with comment separators (e.g. `# --- Create node ---`)
 - Aim for high coverage but focus on meaningful tests
 - Mock external dependencies
 

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -178,43 +178,121 @@ the specified notebook. Returns 204 on success, 404 if not found.
 
 ### Nodes
 
-The resource is `/notebook/.../note/.../node`
-We support the following operations:
+The resource is `/notebook/{notebook_id}/note/{note_id}/node`.
 
-Add node with POST:
-```
+Clients never see or send raw position strings — ordering is an internal
+concern. When listing nodes (via GET on the note), the server returns them
+in order. Clients reference nodes by ID when specifying insertion points.
+
+Both merge nodes must belong to the same note (the one in the URL path).
+
+#### Create node
+
+`POST /notebook/{notebook_id}/note/{note_id}/node`
+
+Requires `X-User-Id` header.
+
+Request body:
+```json
 {
-    position: .... # This is the position of the previous node
-    payload: ....
+    "payload": "Text content",
+    "after_node_id": "uuid (optional)",
+    "before_node_id": "uuid (optional)"
 }
 ```
 
-We pick the position of the previous node and insert the node between that
-position and the next at midpoint
+If neither `after_node_id` nor `before_node_id` is provided, the node is
+appended at the end. If `after_node_id` is provided, the node is inserted
+after that node. Both may be provided to insert between two specific nodes.
 
-PATCH `/notebook/.../note/.../node/...`
-Splits a node
+Response (201):
+```json
 {
-    offset: ... # The character at which to split
+    "id": "uuid",
+    "note_id": "uuid",
+    "author_id": "uuid",
+    "node_type": "text",
+    "payload": "Text content",
+    "version": 1,
+    "creation_timestamp": "2026-01-01T00:00:00Z",
+    "update_timestamp": "2026-01-01T00:00:00Z"
 }
+```
 
-PUT `/notebook/.../note/.../node/...`
-Two options:
-Replace payload
+#### Update node payload
+
+`PATCH /notebook/{notebook_id}/note/{note_id}/node/{node_id}`
+
+Uses a discriminated union body with `type: "update"`.
+
+Request body:
+```json
 {
-    payload: ....
+    "type": "update",
+    "payload": "New text content",
+    "expected_version": 1
 }
+```
 
-Merge nodes. The nodes have to be consecutive.
+Returns 409 if the version doesn't match (optimistic locking). The
+response includes the current version so the client can retry.
+
+Response (200): NodeResponse with bumped version.
+
+#### Merge nodes
+
+`PATCH /notebook/{notebook_id}/note/{note_id}/node/{node_id}`
+
+The URL identifies the **target** node (the one that survives). The source
+node is absorbed and deleted. Both must be text nodes in the same note.
+
+Request body:
+```json
 {
-    nodes: [
-        node1,
-        node2,...
-    ]
+    "type": "merge",
+    "source_node_id": "uuid",
+    "expected_version": 2,
+    "source_expected_version": 1
 }
+```
 
-DELETE `/notebook/.../note/.../node/...`
-Deletes a node.
+`expected_version` is the target's version, `source_expected_version` is
+the source's. Returns 409 if either version doesn't match.
+
+Response (200): NodeResponse of the target with merged payload and bumped
+version.
+
+#### Split node
+
+`POST /notebook/{notebook_id}/note/{note_id}/node/{node_id}/split`
+
+Splits a text node at a character offset. The original node keeps
+`payload[:offset]` and a new node is created with `payload[offset:]`
+immediately after it.
+
+Request body:
+```json
+{
+    "offset": 12,
+    "expected_version": 1
+}
+```
+
+Returns 409 if the version doesn't match.
+
+Response (201):
+```json
+{
+    "original": { "id": "uuid", "payload": "left part", "version": 2, "..." : "..." },
+    "new": { "id": "uuid", "payload": "right part", "version": 1, "..." : "..." }
+}
+```
+
+#### Delete node
+
+`DELETE /notebook/{notebook_id}/note/{note_id}/node/{node_id}`
+
+Deletes a node. Idempotent — returns 204 whether or not the node existed.
 
 **Current state**: Node endpoints are not yet implemented. The service
 layer supports all node operations (add, insert, update, split, merge,

--- a/src/assistant/api/app.py
+++ b/src/assistant/api/app.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from fastapi import FastAPI
 
 from assistant.api.exceptions import register_exception_handlers
+from assistant.api.routes.nodes import router as nodes_router
 from assistant.api.routes.notebooks import router as notebooks_router
 from assistant.api.routes.notes import router as notes_router
 from assistant.api.routes.users import router as users_router
@@ -31,5 +32,6 @@ def create_app(
     app.include_router(users_router, prefix="/user", tags=["users"])
     app.include_router(notebooks_router, prefix="/notebook", tags=["notebooks"])
     app.include_router(notes_router, prefix="/notebook", tags=["notes"])
+    app.include_router(nodes_router, prefix="/notebook", tags=["nodes"])
 
     return app

--- a/src/assistant/api/routes/nodes.py
+++ b/src/assistant/api/routes/nodes.py
@@ -1,0 +1,174 @@
+"""Node API routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Response
+
+from assistant.api.dependencies import CurrentUserId, SessionDep
+from assistant.api.schemas.nodes import (
+    NodeCreate,
+    NodePatch,
+    NodeResponse,
+    NodeSplit,
+    NodeUpdate,
+    SplitResponse,
+)
+from assistant.models.schema import Node
+from assistant.notes.exceptions import NodeNotFoundError, NoteNotFoundError
+from assistant.notes.service import (
+    add_text_node,
+    delete_node,
+    get_note,
+    insert_text_node,
+    merge_text_nodes,
+    split_text_node,
+    update_text_node,
+)
+
+router = APIRouter()
+
+
+def _get_node_in_note(
+    session: SessionDep,
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+    node_id: uuid.UUID,
+) -> Node:
+    note = get_note(session, note_id)
+    if note.notebook_id != notebook_id:
+        raise NoteNotFoundError(str(note_id))
+    node = session.get(Node, node_id)
+    if node is None or node.note_id != note_id:
+        raise NodeNotFoundError(str(node_id))
+    return node
+
+
+def _validate_note_in_notebook(
+    session: SessionDep,
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+) -> None:
+    note = get_note(session, note_id)
+    if note.notebook_id != notebook_id:
+        raise NoteNotFoundError(str(note_id))
+
+
+@router.post(
+    "/{notebook_id}/note/{note_id}/node",
+    status_code=201,
+    response_model=NodeResponse,
+)
+def create_node_endpoint(
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+    body: NodeCreate,
+    session: SessionDep,
+    user_id: CurrentUserId,
+) -> NodeResponse:
+    """Create a text node in a note, optionally positioned between neighbours."""
+    _validate_note_in_notebook(session, notebook_id, note_id)
+    if body.after_node_id is not None or body.before_node_id is not None:
+        node = insert_text_node(
+            session,
+            note_id=note_id,
+            author_id=user_id,
+            payload=body.payload,
+            after_node_id=body.after_node_id,
+            before_node_id=body.before_node_id,
+        )
+    else:
+        node = add_text_node(
+            session,
+            note_id=note_id,
+            author_id=user_id,
+            payload=body.payload,
+        )
+    return NodeResponse.model_validate(node)
+
+
+@router.patch(
+    "/{notebook_id}/note/{note_id}/node/{node_id}",
+    response_model=NodeResponse,
+)
+def patch_node_endpoint(
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+    node_id: uuid.UUID,
+    body: NodePatch,
+    session: SessionDep,
+) -> NodeResponse:
+    """Update a node's payload or merge another node into it."""
+    _get_node_in_note(session, notebook_id, note_id, node_id)
+    if isinstance(body, NodeUpdate):
+        node = update_text_node(
+            session,
+            node_id=node_id,
+            payload=body.payload,
+            expected_version=body.expected_version,
+        )
+    else:
+        _validate_source_in_note(session, note_id, body.source_node_id)
+        node = merge_text_nodes(
+            session,
+            node_id=body.source_node_id,
+            merge_into_id=node_id,
+            expected_version_node=body.source_expected_version,
+            expected_version_target=body.expected_version,
+        )
+    return NodeResponse.model_validate(node)
+
+
+def _validate_source_in_note(
+    session: SessionDep,
+    note_id: uuid.UUID,
+    source_node_id: uuid.UUID,
+) -> None:
+    source = session.get(Node, source_node_id)
+    if source is None or source.note_id != note_id:
+        raise NodeNotFoundError(str(source_node_id))
+
+
+@router.post(
+    "/{notebook_id}/note/{note_id}/node/{node_id}/split",
+    status_code=201,
+    response_model=SplitResponse,
+)
+def split_node_endpoint(  # noqa: PLR0913
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+    node_id: uuid.UUID,
+    body: NodeSplit,
+    session: SessionDep,
+    user_id: CurrentUserId,
+) -> SplitResponse:
+    """Split a text node at a character offset, producing two nodes."""
+    _get_node_in_note(session, notebook_id, note_id, node_id)
+    original, new = split_text_node(
+        session,
+        node_id=node_id,
+        author_id=user_id,
+        split_offset=body.offset,
+        expected_version=body.expected_version,
+    )
+    return SplitResponse(
+        original=NodeResponse.model_validate(original),
+        new=NodeResponse.model_validate(new),
+    )
+
+
+@router.delete(
+    "/{notebook_id}/note/{note_id}/node/{node_id}",
+    status_code=204,
+)
+def delete_node_endpoint(
+    notebook_id: uuid.UUID,
+    note_id: uuid.UUID,
+    node_id: uuid.UUID,
+    session: SessionDep,
+) -> Response:
+    """Delete a node. Idempotent — returns 204 whether or not the node existed."""
+    _validate_note_in_notebook(session, notebook_id, note_id)
+    delete_node(session, node_id)
+    return Response(status_code=204)

--- a/src/assistant/api/schemas/nodes.py
+++ b/src/assistant/api/schemas/nodes.py
@@ -1,0 +1,53 @@
+"""Pydantic schemas for Node endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class NodeCreate(BaseModel):
+    payload: str
+    after_node_id: uuid.UUID | None = None
+    before_node_id: uuid.UUID | None = None
+
+
+class NodeUpdate(BaseModel):
+    type: Literal["update"]
+    payload: str
+    expected_version: int
+
+
+class NodeMerge(BaseModel):
+    type: Literal["merge"]
+    source_node_id: uuid.UUID
+    expected_version: int
+    source_expected_version: int
+
+
+NodePatch = Annotated[NodeUpdate | NodeMerge, Field(discriminator="type")]
+
+
+class NodeSplit(BaseModel):
+    offset: int = Field(ge=0)
+    expected_version: int
+
+
+class NodeResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    note_id: uuid.UUID
+    author_id: uuid.UUID
+    node_type: str
+    payload: str | None
+    version: int
+    update_timestamp: datetime
+
+
+class SplitResponse(BaseModel):
+    original: NodeResponse
+    new: NodeResponse

--- a/src/assistant/cli/api_client.py
+++ b/src/assistant/cli/api_client.py
@@ -118,6 +118,64 @@ def cmd_delete_note(args: argparse.Namespace) -> None:
     _print_response(response)
 
 
+def cmd_create_node(args: argparse.Namespace) -> None:
+    body: dict[str, str] = {"payload": args.payload}
+    if args.after_node_id:
+        body["after_node_id"] = args.after_node_id
+    if args.before_node_id:
+        body["before_node_id"] = args.before_node_id
+    response = httpx.post(
+        f"{args.base_url}/notebook/{args.notebook_id}/note/{args.note_id}/node",
+        json=body,
+        headers={"X-User-Id": args.user_id},
+    )
+    _print_response(response)
+
+
+def cmd_update_node(args: argparse.Namespace) -> None:
+    response = httpx.patch(
+        f"{args.base_url}/notebook/{args.notebook_id}/note/{args.note_id}/node/{args.node_id}",
+        json={
+            "type": "update",
+            "payload": args.payload,
+            "expected_version": args.expected_version,
+        },
+    )
+    _print_response(response)
+
+
+def cmd_merge_node(args: argparse.Namespace) -> None:
+    response = httpx.patch(
+        f"{args.base_url}/notebook/{args.notebook_id}/note/{args.note_id}/node/{args.node_id}",
+        json={
+            "type": "merge",
+            "source_node_id": args.source_node_id,
+            "expected_version": args.expected_version,
+            "source_expected_version": args.source_expected_version,
+        },
+    )
+    _print_response(response)
+
+
+def cmd_split_node(args: argparse.Namespace) -> None:
+    response = httpx.post(
+        f"{args.base_url}/notebook/{args.notebook_id}/note/{args.note_id}/node/{args.node_id}/split",
+        json={
+            "offset": args.offset,
+            "expected_version": args.expected_version,
+        },
+        headers={"X-User-Id": args.user_id},
+    )
+    _print_response(response)
+
+
+def cmd_delete_node(args: argparse.Namespace) -> None:
+    response = httpx.delete(
+        f"{args.base_url}/notebook/{args.notebook_id}/note/{args.note_id}/node/{args.node_id}",
+    )
+    _print_response(response)
+
+
 def _register_user_commands(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -188,6 +246,51 @@ def _register_note_commands(
     p.set_defaults(func=cmd_delete_note)
 
 
+def _register_node_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    p = subparsers.add_parser("create-node")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--note-id", required=True)
+    p.add_argument("--payload", required=True)
+    p.add_argument("--user-id", required=True)
+    p.add_argument("--after-node-id")
+    p.add_argument("--before-node-id")
+    p.set_defaults(func=cmd_create_node)
+
+    p = subparsers.add_parser("update-node")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--note-id", required=True)
+    p.add_argument("--node-id", required=True)
+    p.add_argument("--payload", required=True)
+    p.add_argument("--expected-version", type=int, required=True)
+    p.set_defaults(func=cmd_update_node)
+
+    p = subparsers.add_parser("merge-node")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--note-id", required=True)
+    p.add_argument("--node-id", required=True, help="Target node (survives)")
+    p.add_argument("--source-node-id", required=True, help="Source node (absorbed)")
+    p.add_argument("--expected-version", type=int, required=True)
+    p.add_argument("--source-expected-version", type=int, required=True)
+    p.set_defaults(func=cmd_merge_node)
+
+    p = subparsers.add_parser("split-node")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--note-id", required=True)
+    p.add_argument("--node-id", required=True)
+    p.add_argument("--offset", type=int, required=True)
+    p.add_argument("--expected-version", type=int, required=True)
+    p.add_argument("--user-id", required=True)
+    p.set_defaults(func=cmd_split_node)
+
+    p = subparsers.add_parser("delete-node")
+    p.add_argument("--notebook-id", required=True)
+    p.add_argument("--note-id", required=True)
+    p.add_argument("--node-id", required=True)
+    p.set_defaults(func=cmd_delete_node)
+
+
 def main() -> int:
     """Run the API client CLI."""
     parser = argparse.ArgumentParser(
@@ -202,6 +305,7 @@ def main() -> int:
     _register_user_commands(subparsers)
     _register_notebook_commands(subparsers)
     _register_note_commands(subparsers)
+    _register_node_commands(subparsers)
 
     args = parser.parse_args()
     args.func(args)

--- a/tests/api/test_nodes.py
+++ b/tests/api/test_nodes.py
@@ -1,0 +1,393 @@
+"""Tests for Node API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from assistant.notes.service import (
+    add_text_node,
+    create_note,
+    create_notebook,
+)
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+    from assistant.models.schema import User
+
+
+def _setup(
+    db_session: Session,
+    user: User,
+) -> tuple:
+    """Create a notebook, note, and return (notebook, note)."""
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "Test Note")
+    return nb, note
+
+
+# --- Create node ---
+
+
+def test_create_node_append(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node",
+        json={"payload": "Hello world"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["payload"] == "Hello world"
+    assert data["note_id"] == str(note.id)
+    assert data["version"] == 1
+    assert data["node_type"] == "text"
+
+
+def test_create_node_insert_after(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    first = add_text_node(db_session, note.id, test_user.uid, "First")
+    add_text_node(db_session, note.id, test_user.uid, "Third")
+
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node",
+        json={"payload": "Second", "after_node_id": str(first.id)},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    assert response.json()["payload"] == "Second"
+
+
+def test_create_node_wrong_notebook(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    other_nb = create_notebook(db_session, "Other", test_user.uid)
+    response = client.post(
+        f"/notebook/{other_nb.id}/note/{note.id}/node",
+        json={"payload": "Sneaky"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+def test_create_node_missing_header(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node",
+        json={"payload": "No auth"},
+    )
+    assert response.status_code == 422
+
+
+# --- Update node ---
+
+
+def test_update_node_payload(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    node = add_text_node(db_session, note.id, test_user.uid, "Old")
+
+    response = client.patch(
+        f"/notebook/{nb.id}/note/{note.id}/node/{node.id}",
+        json={
+            "type": "update",
+            "payload": "New",
+            "expected_version": 1,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["payload"] == "New"
+    assert data["version"] == 2
+
+
+def test_update_node_version_conflict(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    node = add_text_node(db_session, note.id, test_user.uid, "Old")
+
+    response = client.patch(
+        f"/notebook/{nb.id}/note/{note.id}/node/{node.id}",
+        json={
+            "type": "update",
+            "payload": "New",
+            "expected_version": 99,
+        },
+    )
+    assert response.status_code == 409
+
+
+def test_update_node_wrong_notebook(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    other_nb = create_notebook(db_session, "Other", test_user.uid)
+    node = add_text_node(db_session, note.id, test_user.uid, "Text")
+
+    response = client.patch(
+        f"/notebook/{other_nb.id}/note/{note.id}/node/{node.id}",
+        json={
+            "type": "update",
+            "payload": "Sneaky",
+            "expected_version": 1,
+        },
+    )
+    assert response.status_code == 404
+
+
+def test_update_node_wrong_note(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    other_note = create_note(db_session, nb.id, test_user.uid, "Other")
+    node = add_text_node(db_session, note.id, test_user.uid, "Text")
+
+    response = client.patch(
+        f"/notebook/{nb.id}/note/{other_note.id}/node/{node.id}",
+        json={
+            "type": "update",
+            "payload": "Sneaky",
+            "expected_version": 1,
+        },
+    )
+    assert response.status_code == 404
+
+
+# --- Merge nodes ---
+
+
+def test_merge_nodes(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    target = add_text_node(db_session, note.id, test_user.uid, "Hello ")
+    source = add_text_node(db_session, note.id, test_user.uid, "World")
+
+    response = client.patch(
+        f"/notebook/{nb.id}/note/{note.id}/node/{target.id}",
+        json={
+            "type": "merge",
+            "source_node_id": str(source.id),
+            "expected_version": 1,
+            "source_expected_version": 1,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["payload"] == "Hello World"
+    assert data["version"] == 2
+
+
+def test_merge_version_conflict(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    target = add_text_node(db_session, note.id, test_user.uid, "A")
+    source = add_text_node(db_session, note.id, test_user.uid, "B")
+
+    response = client.patch(
+        f"/notebook/{nb.id}/note/{note.id}/node/{target.id}",
+        json={
+            "type": "merge",
+            "source_node_id": str(source.id),
+            "expected_version": 99,
+            "source_expected_version": 1,
+        },
+    )
+    assert response.status_code == 409
+
+
+def test_merge_source_not_in_note(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    other_note = create_note(db_session, nb.id, test_user.uid, "Other")
+    target = add_text_node(db_session, note.id, test_user.uid, "A")
+    source = add_text_node(db_session, other_note.id, test_user.uid, "B")
+
+    response = client.patch(
+        f"/notebook/{nb.id}/note/{note.id}/node/{target.id}",
+        json={
+            "type": "merge",
+            "source_node_id": str(source.id),
+            "expected_version": 1,
+            "source_expected_version": 1,
+        },
+    )
+    assert response.status_code == 404
+
+
+def test_merge_source_not_found(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    target = add_text_node(db_session, note.id, test_user.uid, "A")
+
+    response = client.patch(
+        f"/notebook/{nb.id}/note/{note.id}/node/{target.id}",
+        json={
+            "type": "merge",
+            "source_node_id": str(uuid.uuid4()),
+            "expected_version": 1,
+            "source_expected_version": 1,
+        },
+    )
+    assert response.status_code == 404
+
+
+# --- Split node ---
+
+
+def test_split_node(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    node = add_text_node(db_session, note.id, test_user.uid, "HelloWorld")
+
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node/{node.id}/split",
+        json={"offset": 5, "expected_version": 1},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["original"]["payload"] == "Hello"
+    assert data["original"]["version"] == 2
+    assert data["new"]["payload"] == "World"
+    assert data["new"]["version"] == 1
+
+
+def test_split_node_version_conflict(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    node = add_text_node(db_session, note.id, test_user.uid, "HelloWorld")
+
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node/{node.id}/split",
+        json={"offset": 5, "expected_version": 99},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+
+
+def test_split_node_wrong_notebook(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    other_nb = create_notebook(db_session, "Other", test_user.uid)
+    node = add_text_node(db_session, note.id, test_user.uid, "Text")
+
+    response = client.post(
+        f"/notebook/{other_nb.id}/note/{note.id}/node/{node.id}/split",
+        json={"offset": 2, "expected_version": 1},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+def test_split_node_not_found(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node/{uuid.uuid4()}/split",
+        json={"offset": 2, "expected_version": 1},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# --- Delete node ---
+
+
+def test_delete_node(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    node = add_text_node(db_session, note.id, test_user.uid, "Gone")
+
+    response = client.delete(
+        f"/notebook/{nb.id}/note/{note.id}/node/{node.id}",
+    )
+    assert response.status_code == 204
+
+
+def test_delete_node_idempotent(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    response = client.delete(
+        f"/notebook/{nb.id}/note/{note.id}/node/{uuid.uuid4()}",
+    )
+    assert response.status_code == 204
+
+
+def test_delete_node_wrong_notebook(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    other_nb = create_notebook(db_session, "Other", test_user.uid)
+    node = add_text_node(db_session, note.id, test_user.uid, "Text")
+
+    response = client.delete(
+        f"/notebook/{other_nb.id}/note/{note.id}/node/{node.id}",
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Implement Node API endpoints (create, update/merge via PATCH discriminated union, split via POST action, delete) as specified in `docs/architecture/api.md`
- Update `docs/architecture/api.md` with the refined Node endpoint spec (proper REST semantics, optimistic locking via body, positions hidden from clients)
- Update `AGENTS.md` with accurate project structure and test conventions (module-level functions, no classes)
- Add node commands to the CLI client (`create-node`, `update-node`, `merge-node`, `split-node`, `delete-node`)

## Test plan

- [x] 19 new API tests covering all node operations (happy path + error cases)
- [x] All 48 API tests pass
- [x] mypy clean, ruff clean, pre-commit hooks pass
- [x] 100% coverage on new route and schema files

🤖 Generated with [Claude Code](https://claude.com/claude-code)