### PR TITLE
feat: add markdown block support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install-uv setup sync install test typecheck lint format check clean pre-commit-install pre-commit-run services-up services-down server frontend-install frontend-dev frontend-build frontend-lint frontend-check dev
+.PHONY: help install-uv setup sync install test typecheck lint format check clean pre-commit-install pre-commit-run services-up services-down server frontend-install frontend-dev frontend-build frontend-lint frontend-check dev dev-stop
 
 # Default target
 help:
@@ -23,6 +23,7 @@ help:
 	@echo "  make frontend-lint       - Lint frontend code"
 	@echo "  make frontend-check      - Run all frontend checks"
 	@echo "  make dev                 - Start both backend and frontend dev servers"
+	@echo "  make dev-stop            - Stop backend and frontend dev servers"
 	@echo "  make clean               - Remove generated files and cache"
 
 # Install uv package manager
@@ -151,6 +152,13 @@ frontend-check: frontend-lint
 dev:
 	@echo "Starting backend and frontend..."
 	@.venv/bin/python -m assistant.cli.api_server & cd frontend && npm run dev
+
+# Stop backend and frontend dev servers
+dev-stop:
+	@echo "Stopping dev servers..."
+	@lsof -ti:8000 | xargs kill 2>/dev/null || true
+	@lsof -ti:5173 | xargs kill 2>/dev/null || true
+	@echo "Dev servers stopped"
 
 # Quick development setup (run once)
 dev-setup: setup install pre-commit-install

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -155,3 +155,4 @@ the webui.
 
 - [`Notes Service`](notesservice.md)
 - [`API`](api.md)
+- [`Markdown support`](markdown.md)

--- a/docs/architecture/markdown.md
+++ b/docs/architecture/markdown.md
@@ -1,0 +1,79 @@
+# Markdown Support
+
+We support multiple notes format. At this point we support Markdown
+only. This document describes the architecture of the Markdown
+support.
+
+## Overall architecture
+
+We store notes through a sequence of nodes - [`Notes Service`](../architecture/notesservice.md). We are going to leverage Nodes to identify markdown blocks.
+
+This will allow us to permit concurrent modifications. This means we represent
+the Note with a Node per block and that the client must be aware of a nodes
+data structure so it can decide which nodes to update and where to insert a Node.
+
+## Matkdown blocks
+
+These are the blocks that we model as nodes:
+
+- Headings (all of them and in both the single line and multiline form)
+
+- Paragraph. Each paragraph is a Node. Emphasis does not breal the paragraph node.
+  Links are not breaking Node.
+
+- Blockquotes. Nested quotes do not break the Node. Same is true for sub blocks
+  in a Blockquote
+
+- Each element of a list is a Node
+
+- Images
+
+- Code blocks (each block is a Node)
+
+## Data model
+
+We have a Markdown Node type in `NodeType` enum. The Markdown node contains
+information on the node type: paragraph, header, etc. The text in the node
+is the markdown content of the block.
+
+This means that we can concatenate the The payloads of all the nodes adding
+a newline between each nodes and we have a renderable version of the document.
+
+The client has an in memory data structure to represent the document that
+reflects the one in the server and allows us to map a line number in the
+textbox to the node so we can tell where to add a Node or which one to update.
+
+The client data structure is a sequence of blocks. Each block corresponds to a
+node and contains the Markdown content. This sequence is modeled as a doubly
+linked list and also contains information on the number of lines the node
+contains.
+
+```mermaid
+flowchart LR
+
+subgraph note["Clientside Note"]
+    node1["Node 1 - Header; content: # Title; lines: 1"]
+    node2["Node 2 - Paragraph; content: text; lines: 5"]
+    node3["Node 3 - Bullet; content: - bullet; lines: 1"]
+
+    node1 --> node2
+    node2 --> node3
+    node2 --> node1
+    node3 --> node2
+end
+cursor["UI cursor - line: 3"]
+
+cursor --> node2
+```
+
+Each client node contains the number of lines the block contains. The UI code
+keeps a reference between the cursor position (the line number) and the Node.
+
+- If a user types enter to create a new block, the block is added in the linked
+  list in the right place.
+
+- When the cursor moves we scan the list and update the reference to the right
+  node.
+
+When we save the node it is easier to compute the updates we did to the linked
+list and turn them into calls to the api that adds, delete and updates nodes.

--- a/docs/architecture/notesservice.md
+++ b/docs/architecture/notesservice.md
@@ -19,6 +19,7 @@ erDiagram
     User ||--o{ Note : "owns"
     Notebook ||--o{ Note : "contains"
     Note ||--o{ TextNode : "composed"
+    Note ||--o{ MarkdownNode : "composed"
     Note ||--o{ AttachmentNode : "composed"
     AttachmentNode ||--|| AttachmentMetadata : "composed"
 
@@ -50,6 +51,15 @@ erDiagram
         position: VARCHAR
         author: UUID FK
         payload: STRING
+    }
+
+    MarkdownNode {
+        id: UUID PK
+        note_id: UUID FK
+        position: VARCHAR
+        author: UUID FK
+        payload: STRING
+        block_type: STRING
     }
 
     AttachmentNode {

--- a/frontend/src/api/nodes.ts
+++ b/frontend/src/api/nodes.ts
@@ -5,19 +5,54 @@ export function fetchNodes(notebookId: string, noteId: string): Promise<NoteNode
   return apiFetch<NoteNode[]>(`/notebook/${notebookId}/note/${noteId}/node`);
 }
 
+export function createNode(
+  notebookId: string,
+  noteId: string,
+  payload: string,
+  opts: {
+    blockType?: string;
+    afterNodeId?: string;
+    beforeNodeId?: string;
+    userId?: string;
+  } = {},
+): Promise<NoteNode> {
+  const body: Record<string, string> = { payload };
+  if (opts.blockType) body.block_type = opts.blockType;
+  if (opts.afterNodeId) body.after_node_id = opts.afterNodeId;
+  if (opts.beforeNodeId) body.before_node_id = opts.beforeNodeId;
+  return apiFetch<NoteNode>(`/notebook/${notebookId}/note/${noteId}/node`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    userId: opts.userId,
+  });
+}
+
 export function updateNode(
   notebookId: string,
   noteId: string,
   nodeId: string,
   payload: string,
   expectedVersion: number,
+  blockType?: string,
 ): Promise<NoteNode> {
+  const body: Record<string, unknown> = {
+    type: 'update',
+    payload,
+    expected_version: expectedVersion,
+  };
+  if (blockType !== undefined) body.block_type = blockType;
   return apiFetch<NoteNode>(`/notebook/${notebookId}/note/${noteId}/node/${nodeId}`, {
     method: 'PATCH',
-    body: JSON.stringify({
-      type: 'update',
-      payload,
-      expected_version: expectedVersion,
-    }),
+    body: JSON.stringify(body),
+  });
+}
+
+export function deleteNode(
+  notebookId: string,
+  noteId: string,
+  nodeId: string,
+): Promise<void> {
+  return apiFetch<void>(`/notebook/${notebookId}/note/${noteId}/node/${nodeId}`, {
+    method: 'DELETE',
   });
 }

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -1,15 +1,50 @@
-import { useState, useEffect } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'react-router';
-import { fetchNodes, updateNode } from '../api/nodes';
-import type { NoteNode } from '../types';
+import { fetchNodes } from '../api/nodes';
+import { BlockList } from '../markdown/blockList';
+import type { BlockNode } from '../markdown/blockList';
+import { executeSave } from '../markdown/reconcile';
+import { useUser } from '../contexts/UserContext';
+
+function lineFromCharOffset(text: string, charOffset: number): number {
+  let line = 0;
+  for (let i = 0; i < charOffset && i < text.length; i++) {
+    if (text[i] === '\n') line++;
+  }
+  return line;
+}
+
+function charOffsetOfBlock(bl: BlockList, target: BlockNode): number {
+  let offset = 0;
+  let current = bl.head;
+  while (current !== null && current !== target) {
+    offset += current.content.length + 2; // +2 for \n\n separator
+    current = current.next;
+  }
+  return offset;
+}
+
+function charLengthAfterBlock(block: BlockNode): number {
+  let length = 0;
+  let current = block.next;
+  while (current !== null) {
+    length += 2 + current.content.length; // +2 for \n\n separator
+    current = current.next;
+  }
+  return length;
+}
 
 export default function NoteEditor() {
   const { notebookId, noteId } = useParams();
   const queryClient = useQueryClient();
+  const { userId } = useUser();
   const [text, setText] = useState('');
-  const [currentNode, setCurrentNode] = useState<NoteNode | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const blockListRef = useRef<BlockList>(new BlockList());
+  const currentBlockRef = useRef<BlockNode | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const { data: nodes, isLoading } = useQuery({
     queryKey: ['nodes', notebookId, noteId],
@@ -18,36 +53,94 @@ export default function NoteEditor() {
   });
 
   useEffect(() => {
-    if (nodes && nodes.length > 0) {
-      const node = nodes[0];
-      setCurrentNode(node);
-      setText(node.payload ?? '');
-      setStatus(null);
-    }
+    if (!nodes || nodes.length === 0) return;
+
+    const bl = blockListRef.current;
+    bl.buildFromServerNodes(nodes);
+    setText(bl.toText());
+    currentBlockRef.current = bl.head;
+    setStatus(null);
   }, [nodes]);
 
-  const saveMutation = useMutation({
-    mutationFn: () =>
-      updateNode(
-        notebookId!,
-        noteId!,
-        currentNode!.id,
-        text,
-        currentNode!.version,
-      ),
-    onSuccess: (updated) => {
-      setCurrentNode(updated);
+  const handleTextChange = useCallback((newText: string) => {
+    const bl = blockListRef.current;
+    const cursorPos = textareaRef.current?.selectionStart ?? 0;
+    const cursorLine = lineFromCharOffset(newText, cursorPos);
+
+    const currentBlock = currentBlockRef.current ?? bl.head;
+    if (!currentBlock) {
+      setText(newText);
+      return;
+    }
+
+    const blockStart = charOffsetOfBlock(bl, currentBlock);
+    const afterLength = charLengthAfterBlock(currentBlock);
+    const blockEnd = newText.length - afterLength;
+    const blockContent = newText.slice(blockStart, blockEnd);
+
+    const doubleNewlineIdx = blockContent.indexOf('\n\n');
+    if (doubleNewlineIdx !== -1) {
+      const topContent = blockContent.slice(0, doubleNewlineIdx);
+      const bottomContent = blockContent.slice(doubleNewlineIdx + 2);
+
+      bl.updateBlock(currentBlock, topContent);
+      const newBlock = bl.insertAfter(currentBlock, 'paragraph', bottomContent);
+      bl.updateBlock(newBlock, bottomContent);
+      currentBlockRef.current = newBlock;
+
+      const rebuilt = bl.toText();
+      setText(rebuilt);
+      setStatus(null);
+      return;
+    }
+
+    // Check for merge: if extracted content is longer than the current block
+    // plus the next block, the separator between them was removed
+    if (currentBlock.next && blockEnd > blockStart + currentBlock.content.length + 2 + currentBlock.next.content.length) {
+      bl.updateBlock(currentBlock, blockContent);
+      if (currentBlock.next) {
+        bl.remove(currentBlock.next);
+      }
+      const rebuilt = bl.toText();
+      setText(rebuilt);
+      currentBlockRef.current = currentBlock;
+      setStatus(null);
+      return;
+    }
+
+    bl.updateBlock(currentBlock, blockContent);
+
+    currentBlockRef.current = bl.getBlockAtLine(cursorLine);
+    setText(newText);
+    setStatus(null);
+  }, []);
+
+  const handleCursorMove = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const cursorLine = lineFromCharOffset(text, textarea.selectionStart);
+    const bl = blockListRef.current;
+    currentBlockRef.current = bl.getBlockAtLine(cursorLine);
+  }, [text]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setStatus(null);
+
+    try {
+      await executeSave(notebookId!, noteId!, blockListRef.current, userId);
       setStatus('Saved');
       queryClient.invalidateQueries({ queryKey: ['nodes', notebookId, noteId] });
-    },
-    onError: (err) => {
+    } catch (err) {
       if (err instanceof Error && err.message.includes('409')) {
         setStatus('Conflict: note was modified externally. Please refresh.');
       } else {
-        setStatus(`Error: ${err.message}`);
+        setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
       }
-    },
-  });
+    } finally {
+      setSaving(false);
+    }
+  }, [notebookId, noteId, userId, queryClient]);
 
   if (!notebookId || !noteId) {
     return <div className="editor-placeholder">Select a note to edit</div>;
@@ -55,27 +148,28 @@ export default function NoteEditor() {
 
   if (isLoading) return <div>Loading...</div>;
 
-  if (!currentNode) {
+  if (blockListRef.current.head === null && (!nodes || nodes.length === 0)) {
     return <div className="editor-placeholder">No content</div>;
   }
 
-  const isDirty = text !== (currentNode.payload ?? '');
+  const isDirty = blockListRef.current.toArray().some(b => b.dirty)
+    || blockListRef.current.deletedNodeIds.length > 0;
 
   return (
     <div className="note-editor">
       <textarea
+        ref={textareaRef}
         value={text}
-        onChange={(e) => {
-          setText(e.target.value);
-          setStatus(null);
-        }}
+        onChange={(e) => handleTextChange(e.target.value)}
+        onSelect={handleCursorMove}
+        onKeyUp={handleCursorMove}
       />
       <div className="editor-toolbar">
         <button
-          onClick={() => saveMutation.mutate()}
-          disabled={!isDirty || saveMutation.isPending}
+          onClick={handleSave}
+          disabled={!isDirty || saving}
         >
-          {saveMutation.isPending ? 'Saving...' : 'Save'}
+          {saving ? 'Saving...' : 'Save'}
         </button>
         {status && <span className={`status ${status.startsWith('Error') || status.startsWith('Conflict') ? 'error' : 'success'}`}>{status}</span>}
       </div>

--- a/frontend/src/markdown/blockList.ts
+++ b/frontend/src/markdown/blockList.ts
@@ -1,0 +1,241 @@
+import type { MarkdownBlockType, NoteNode } from '../types';
+import { classifyBlockType, parseMarkdownBlocks } from './parser';
+
+export interface BlockNode {
+  prev: BlockNode | null;
+  next: BlockNode | null;
+  blockType: MarkdownBlockType;
+  content: string;
+  lineCount: number;
+  lineStart: number;
+  serverState: { nodeId: string; version: number; nodeType: string } | null;
+  dirty: boolean;
+}
+
+function countLines(content: string): number {
+  if (content === '') return 1;
+  return content.split('\n').length;
+}
+
+export class BlockList {
+  head: BlockNode | null = null;
+  tail: BlockNode | null = null;
+  deletedNodeIds: string[] = [];
+
+  buildFromServerNodes(nodes: NoteNode[]): void {
+    this.head = null;
+    this.tail = null;
+    this.deletedNodeIds = [];
+
+    for (const node of nodes) {
+      const content = node.payload ?? '';
+
+      if (node.node_type === 'markdown') {
+        const block: BlockNode = {
+          prev: null,
+          next: null,
+          blockType: (node.block_type as MarkdownBlockType) ?? classifyBlockType(content),
+          content,
+          lineCount: countLines(content),
+          lineStart: 0,
+          serverState: { nodeId: node.id, version: node.version, nodeType: 'markdown' },
+          dirty: false,
+        };
+        this.appendBlock(block);
+      } else {
+        // TEXT nodes: parse content into blocks so multi-block text gets split
+        const parsed = parseMarkdownBlocks(content);
+        for (let i = 0; i < parsed.length; i++) {
+          const block: BlockNode = {
+            prev: null,
+            next: null,
+            blockType: parsed[i].blockType,
+            content: parsed[i].content,
+            lineCount: parsed[i].lineCount,
+            lineStart: 0,
+            serverState: i === 0
+              ? { nodeId: node.id, version: node.version, nodeType: 'text' }
+              : null,
+            dirty: i > 0,
+          };
+          this.appendBlock(block);
+        }
+      }
+    }
+
+    this.recomputeLineStarts();
+  }
+
+  buildFromText(text: string): void {
+    this.head = null;
+    this.tail = null;
+    this.deletedNodeIds = [];
+
+    const parsed = parseMarkdownBlocks(text);
+    for (const p of parsed) {
+      const block: BlockNode = {
+        prev: null,
+        next: null,
+        blockType: p.blockType,
+        content: p.content,
+        lineCount: p.lineCount,
+        lineStart: 0,
+        serverState: null,
+        dirty: true,
+      };
+      this.appendBlock(block);
+    }
+
+    this.recomputeLineStarts();
+  }
+
+  private appendBlock(block: BlockNode): void {
+    if (this.tail === null) {
+      this.head = block;
+      this.tail = block;
+    } else {
+      block.prev = this.tail;
+      this.tail.next = block;
+      this.tail = block;
+    }
+  }
+
+  getBlockAtLine(line: number): BlockNode | null {
+    let current = this.head;
+    while (current !== null) {
+      if (line >= current.lineStart && line < current.lineStart + current.lineCount) {
+        return current;
+      }
+      current = current.next;
+    }
+    return this.tail;
+  }
+
+  insertAfter(after: BlockNode | null, blockType: MarkdownBlockType, content: string): BlockNode {
+    const block: BlockNode = {
+      prev: null,
+      next: null,
+      blockType,
+      content,
+      lineCount: countLines(content),
+      lineStart: 0,
+      serverState: null,
+      dirty: true,
+    };
+
+    if (after === null) {
+      // Insert at head
+      block.next = this.head;
+      if (this.head) this.head.prev = block;
+      this.head = block;
+      if (this.tail === null) this.tail = block;
+    } else {
+      block.prev = after;
+      block.next = after.next;
+      if (after.next) after.next.prev = block;
+      after.next = block;
+      if (after === this.tail) this.tail = block;
+    }
+
+    this.recomputeLineStarts();
+    return block;
+  }
+
+  remove(block: BlockNode): void {
+    if (block.serverState) {
+      this.deletedNodeIds.push(block.serverState.nodeId);
+    }
+
+    if (block.prev) {
+      block.prev.next = block.next;
+    } else {
+      this.head = block.next;
+    }
+
+    if (block.next) {
+      block.next.prev = block.prev;
+    } else {
+      this.tail = block.prev;
+    }
+
+    block.prev = null;
+    block.next = null;
+    this.recomputeLineStarts();
+  }
+
+  updateBlock(block: BlockNode, newContent: string): void {
+    block.content = newContent;
+    block.lineCount = countLines(newContent);
+    block.blockType = classifyBlockType(newContent);
+    block.dirty = true;
+    this.recomputeLineStarts();
+  }
+
+  splitBlock(block: BlockNode, localLineOffset: number): BlockNode {
+    const lines = block.content.split('\n');
+    const topContent = lines.slice(0, localLineOffset).join('\n');
+    const bottomContent = lines.slice(localLineOffset).join('\n');
+
+    block.content = topContent;
+    block.lineCount = countLines(topContent);
+    block.blockType = classifyBlockType(topContent);
+    block.dirty = true;
+
+    const newBlock = this.insertAfter(block, classifyBlockType(bottomContent), bottomContent);
+    return newBlock;
+  }
+
+  mergeWithNext(block: BlockNode): void {
+    const next = block.next;
+    if (!next) return;
+
+    block.content = block.content + '\n' + next.content;
+    block.lineCount = countLines(block.content);
+    block.blockType = classifyBlockType(block.content);
+    block.dirty = true;
+
+    this.remove(next);
+  }
+
+  toText(): string {
+    const parts: string[] = [];
+    let current = this.head;
+    while (current !== null) {
+      parts.push(current.content);
+      current = current.next;
+    }
+    return parts.join('\n\n');
+  }
+
+  recomputeLineStarts(): void {
+    let lineStart = 0;
+    let current = this.head;
+    let isFirst = true;
+    while (current !== null) {
+      if (!isFirst) {
+        lineStart += 1; // blank separator line between blocks
+      }
+      current.lineStart = lineStart;
+      lineStart += current.lineCount;
+      current = current.next;
+      isFirst = false;
+    }
+  }
+
+  toArray(): BlockNode[] {
+    const result: BlockNode[] = [];
+    let current = this.head;
+    while (current !== null) {
+      result.push(current);
+      current = current.next;
+    }
+    return result;
+  }
+
+  totalLines(): number {
+    const blocks = this.toArray();
+    if (blocks.length === 0) return 0;
+    const last = blocks[blocks.length - 1];
+    return last.lineStart + last.lineCount;
+  }
+}

--- a/frontend/src/markdown/parser.ts
+++ b/frontend/src/markdown/parser.ts
@@ -1,0 +1,70 @@
+import type { MarkdownBlockType } from '../types';
+
+export interface ParsedBlock {
+  blockType: MarkdownBlockType;
+  content: string;
+  lineCount: number;
+}
+
+export function classifyBlockType(content: string): MarkdownBlockType {
+  const firstLine = content.split('\n')[0].trimStart();
+  if (/^#{1,6}\s/.test(firstLine)) return 'heading';
+  if (firstLine.startsWith('>')) return 'blockquote';
+  if (/^[-*+]\s/.test(firstLine) || /^\d+\.\s/.test(firstLine)) return 'list_item';
+  if (firstLine.startsWith('![')) return 'image';
+  if (firstLine.startsWith('```')) return 'code_block';
+  return 'paragraph';
+}
+
+export function parseMarkdownBlocks(text: string): ParsedBlock[] {
+  if (text === '') {
+    return [{ blockType: 'paragraph', content: '', lineCount: 1 }];
+  }
+
+  const blocks: ParsedBlock[] = [];
+  const lines = text.split('\n');
+  let i = 0;
+
+  while (i < lines.length) {
+    if (lines[i].startsWith('```')) {
+      const startLine = i;
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        i++;
+      }
+      if (i < lines.length) i++; // consume closing ```
+      const content = lines.slice(startLine, i).join('\n');
+      blocks.push({
+        blockType: 'code_block',
+        content,
+        lineCount: i - startLine,
+      });
+      continue;
+    }
+
+    const startLine = i;
+    while (i < lines.length && lines[i] !== '' && !lines[i].startsWith('```')) {
+      i++;
+    }
+
+    if (i > startLine) {
+      const content = lines.slice(startLine, i).join('\n');
+      blocks.push({
+        blockType: classifyBlockType(content),
+        content,
+        lineCount: i - startLine,
+      });
+    }
+
+    // Skip blank lines between blocks
+    while (i < lines.length && lines[i] === '') {
+      i++;
+    }
+  }
+
+  if (blocks.length === 0) {
+    blocks.push({ blockType: 'paragraph', content: '', lineCount: 1 });
+  }
+
+  return blocks;
+}

--- a/frontend/src/markdown/reconcile.ts
+++ b/frontend/src/markdown/reconcile.ts
@@ -1,0 +1,74 @@
+import type { BlockList, BlockNode } from './blockList';
+import { createNode, deleteNode, updateNode } from '../api/nodes';
+
+export async function executeSave(
+  notebookId: string,
+  noteId: string,
+  blockList: BlockList,
+  userId: string,
+): Promise<void> {
+  // 1. Delete removed blocks
+  for (const nodeId of blockList.deletedNodeIds) {
+    await deleteNode(notebookId, noteId, nodeId);
+  }
+  blockList.deletedNodeIds = [];
+
+  // 2. Delete old TEXT nodes that need to be replaced with MARKDOWN nodes
+  const blocks = blockList.toArray();
+  for (const block of blocks) {
+    if (block.dirty && block.serverState !== null && block.serverState.nodeType === 'text') {
+      await deleteNode(notebookId, noteId, block.serverState.nodeId);
+      block.serverState = null;
+    }
+  }
+
+  // 3. Create new blocks (in order, so afterNodeId is available)
+  for (const block of blocks) {
+    if (block.serverState === null) {
+      const afterNodeId = findPreviousServerNodeId(block);
+      const beforeNodeId = findNextServerNodeId(block);
+      const created = await createNode(notebookId, noteId, block.content, {
+        blockType: block.blockType,
+        afterNodeId: afterNodeId ?? undefined,
+        beforeNodeId: beforeNodeId ?? undefined,
+        userId,
+      });
+      block.serverState = { nodeId: created.id, version: created.version, nodeType: 'markdown' };
+      block.dirty = false;
+    }
+  }
+
+  // 4. Update dirty markdown blocks
+  for (const block of blocks) {
+    if (block.dirty && block.serverState !== null) {
+      const updated = await updateNode(
+        notebookId,
+        noteId,
+        block.serverState.nodeId,
+        block.content,
+        block.serverState.version,
+        block.blockType,
+      );
+      block.serverState.version = updated.version;
+      block.dirty = false;
+    }
+  }
+}
+
+function findPreviousServerNodeId(block: BlockNode): string | null {
+  let prev = block.prev;
+  while (prev !== null) {
+    if (prev.serverState) return prev.serverState.nodeId;
+    prev = prev.prev;
+  }
+  return null;
+}
+
+function findNextServerNodeId(block: BlockNode): string | null {
+  let next = block.next;
+  while (next !== null) {
+    if (next.serverState) return next.serverState.nodeId;
+    next = next.next;
+  }
+  return null;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -20,12 +20,15 @@ export interface Note {
   update_timestamp: string;
 }
 
+export type MarkdownBlockType = 'paragraph' | 'heading' | 'blockquote' | 'list_item' | 'image' | 'code_block';
+
 export interface NoteNode {
   id: string;
   note_id: string;
   author_id: string;
   node_type: string;
   payload: string | null;
+  block_type: string | null;
   version: number;
   update_timestamp: string;
 }

--- a/src/assistant/api/exceptions.py
+++ b/src/assistant/api/exceptions.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.exc import IntegrityError
 
 from assistant.notes.exceptions import (
+    InvalidBlockTypeError,
     NodeVersionConflictError,
     NotesServiceError,
     UserNotFoundError,
@@ -27,6 +28,13 @@ def register_exception_handlers(app: FastAPI) -> None:
         exc: UserNotFoundError,
     ) -> JSONResponse:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(InvalidBlockTypeError)
+    async def invalid_block_type_handler(
+        request: Request,  # noqa: ARG001
+        exc: InvalidBlockTypeError,
+    ) -> JSONResponse:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
 
     @app.exception_handler(NodeVersionConflictError)
     async def version_conflict_handler(

--- a/src/assistant/api/routes/nodes.py
+++ b/src/assistant/api/routes/nodes.py
@@ -18,13 +18,16 @@ from assistant.api.schemas.nodes import (
 from assistant.models.schema import Node
 from assistant.notes.exceptions import NodeNotFoundError, NoteNotFoundError
 from assistant.notes.service import (
+    add_markdown_node,
     add_text_node,
     delete_node,
     get_note,
     get_ordered_nodes,
+    insert_markdown_node,
     insert_text_node,
     merge_text_nodes,
     split_text_node,
+    update_markdown_node,
     update_text_node,
 )
 
@@ -83,9 +86,29 @@ def create_node_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> NodeResponse:
-    """Create a text node in a note, optionally positioned between neighbours."""
+    """Create a node in a note, optionally positioned between neighbours."""
     _validate_note_in_notebook(session, notebook_id, note_id)
-    if body.after_node_id is not None or body.before_node_id is not None:
+    has_neighbors = body.after_node_id is not None or body.before_node_id is not None
+    if body.block_type is not None:
+        if has_neighbors:
+            node = insert_markdown_node(
+                session,
+                note_id=note_id,
+                author_id=user_id,
+                payload=body.payload,
+                block_type=body.block_type,
+                after_node_id=body.after_node_id,
+                before_node_id=body.before_node_id,
+            )
+        else:
+            node = add_markdown_node(
+                session,
+                note_id=note_id,
+                author_id=user_id,
+                payload=body.payload,
+                block_type=body.block_type,
+            )
+    elif has_neighbors:
         node = insert_text_node(
             session,
             note_id=note_id,
@@ -118,12 +141,21 @@ def patch_node_endpoint(
     """Update a node's payload or merge another node into it."""
     _get_node_in_note(session, notebook_id, note_id, node_id)
     if isinstance(body, NodeUpdate):
-        node = update_text_node(
-            session,
-            node_id=node_id,
-            payload=body.payload,
-            expected_version=body.expected_version,
-        )
+        if body.block_type is not None:
+            node = update_markdown_node(
+                session,
+                node_id=node_id,
+                payload=body.payload,
+                block_type=body.block_type,
+                expected_version=body.expected_version,
+            )
+        else:
+            node = update_text_node(
+                session,
+                node_id=node_id,
+                payload=body.payload,
+                expected_version=body.expected_version,
+            )
     else:
         _validate_source_in_note(session, note_id, body.source_node_id)
         node = merge_text_nodes(

--- a/src/assistant/api/schemas/nodes.py
+++ b/src/assistant/api/schemas/nodes.py
@@ -13,12 +13,14 @@ class NodeCreate(BaseModel):
     payload: str
     after_node_id: uuid.UUID | None = None
     before_node_id: uuid.UUID | None = None
+    block_type: str | None = None
 
 
 class NodeUpdate(BaseModel):
     type: Literal["update"]
     payload: str
     expected_version: int
+    block_type: str | None = None
 
 
 class NodeMerge(BaseModel):
@@ -44,6 +46,7 @@ class NodeResponse(BaseModel):
     author_id: uuid.UUID
     node_type: str
     payload: str | None
+    block_type: str | None = None
     version: int
     update_timestamp: datetime
 

--- a/src/assistant/models/schema.py
+++ b/src/assistant/models/schema.py
@@ -34,6 +34,18 @@ class NodeType(str, Enum):
 
     TEXT = "text"
     ATTACHMENT = "attachment"
+    MARKDOWN = "markdown"
+
+
+class MarkdownBlockType(str, Enum):
+    """Markdown block type enumeration."""
+
+    PARAGRAPH = "paragraph"
+    HEADING = "heading"
+    BLOCKQUOTE = "blockquote"
+    LIST_ITEM = "list_item"
+    IMAGE = "image"
+    CODE_BLOCK = "code_block"
 
 
 class User(Base):
@@ -165,10 +177,13 @@ class Node(Base):
     __table_args__ = (
         CheckConstraint(
             "(node_type = 'text' AND payload IS NOT NULL"
-            " AND attachment_id IS NULL)"
+            " AND attachment_id IS NULL AND block_type IS NULL)"
             " OR "
             "(node_type = 'attachment' AND payload IS NULL"
-            " AND attachment_id IS NOT NULL)",
+            " AND attachment_id IS NOT NULL AND block_type IS NULL)"
+            " OR "
+            "(node_type = 'markdown' AND payload IS NOT NULL"
+            " AND attachment_id IS NULL AND block_type IS NOT NULL)",
             name="ck_node_type_fields",
         ),
         Index("ix_nodes_note_id_position", "note_id", "position"),
@@ -193,6 +208,7 @@ class Node(Base):
     )
     node_type: Mapped[str] = mapped_column(String(20), nullable=False)
     payload: Mapped[str | None] = mapped_column(Text, nullable=True)
+    block_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
     attachment_id: Mapped[uuid_module.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("assistant.attachment_metadata.id"),

--- a/src/assistant/notes/exceptions.py
+++ b/src/assistant/notes/exceptions.py
@@ -32,6 +32,10 @@ class InvalidNodeTypeError(NotesServiceError):
     """Raised when an operation is applied to the wrong node type."""
 
 
+class InvalidBlockTypeError(NotesServiceError):
+    """Raised when an invalid markdown block type is provided."""
+
+
 class NodeVersionConflictError(NotesServiceError):
     """Raised when optimistic locking detects a version conflict."""
 

--- a/src/assistant/notes/service.py
+++ b/src/assistant/notes/service.py
@@ -71,12 +71,14 @@ from sqlalchemy import select, update
 
 from assistant.models.schema import (
     AttachmentMetadata,
+    MarkdownBlockType,
     Node,
     NodeType,
     Note,
     Notebook,
 )
 from assistant.notes.exceptions import (
+    InvalidBlockTypeError,
     InvalidNodeTypeError,
     NodeNotFoundError,
     NodeVersionConflictError,
@@ -350,6 +352,141 @@ def insert_text_node(  # noqa: PLR0913
     )
     session.add(node)
     _touch_note(session, note_id)
+    session.flush()
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Markdown node operations
+# ---------------------------------------------------------------------------
+
+
+def _validate_block_type(block_type: str) -> MarkdownBlockType:
+    try:
+        return MarkdownBlockType(block_type)
+    except ValueError:
+        valid = ", ".join(bt.value for bt in MarkdownBlockType)
+        msg = f"Invalid block type '{block_type}'. Must be one of: {valid}"
+        raise InvalidBlockTypeError(msg) from None
+
+
+def _ensure_markdown_node(node: Node) -> None:
+    if node.node_type != NodeType.MARKDOWN:
+        msg = f"Node {node.id} is {node.node_type}, expected markdown"
+        raise InvalidNodeTypeError(msg)
+
+
+def add_markdown_node(
+    session: Session,
+    note_id: uuid.UUID,
+    author_id: uuid.UUID,
+    payload: str,
+    block_type: str,
+) -> Node:
+    """Append a markdown node at the end of a note's content list."""
+    validated_bt = _validate_block_type(block_type)
+    last = _last_position(session, note_id, lock=True)
+    position = generate_position_between(last, None)
+    node = Node(
+        note_id=note_id,
+        position=position,
+        author_id=author_id,
+        node_type=NodeType.MARKDOWN,
+        payload=payload,
+        block_type=validated_bt.value,
+    )
+    session.add(node)
+    _touch_note(session, note_id)
+    session.flush()
+    return node
+
+
+def insert_markdown_node(  # noqa: PLR0913
+    session: Session,
+    note_id: uuid.UUID,
+    author_id: uuid.UUID,
+    payload: str,
+    block_type: str,
+    after_node_id: uuid.UUID | None = None,
+    before_node_id: uuid.UUID | None = None,
+) -> Node:
+    """Insert a markdown node between two existing nodes.
+
+    At least one of *after_node_id* or *before_node_id* must be provided.
+    """
+    validated_bt = _validate_block_type(block_type)
+    before_pos: str | None = None
+    after_pos: str | None = None
+
+    if after_node_id is not None:
+        after_node = session.execute(
+            select(Node).where(Node.id == after_node_id).with_for_update(),
+        ).scalar_one_or_none()
+        if after_node is None:
+            raise NodeNotFoundError(str(after_node_id))
+        after_pos = after_node.position
+
+    if before_node_id is not None:
+        before_node = session.execute(
+            select(Node).where(Node.id == before_node_id).with_for_update(),
+        ).scalar_one_or_none()
+        if before_node is None:
+            raise NodeNotFoundError(str(before_node_id))
+        before_pos = before_node.position
+
+    position = generate_position_between(after_pos, before_pos)
+    node = Node(
+        note_id=note_id,
+        position=position,
+        author_id=author_id,
+        node_type=NodeType.MARKDOWN,
+        payload=payload,
+        block_type=validated_bt.value,
+    )
+    session.add(node)
+    _touch_note(session, note_id)
+    session.flush()
+    return node
+
+
+def update_markdown_node(
+    session: Session,
+    node_id: uuid.UUID,
+    payload: str,
+    block_type: str,
+    expected_version: int,
+) -> Node:
+    """Update a markdown node's payload and block type.
+
+    Uses the same optimistic locking as ``update_text_node``.
+    """
+    validated_bt = _validate_block_type(block_type)
+    node = session.get(Node, node_id)
+    if node is None:
+        raise NodeNotFoundError(str(node_id))
+    _ensure_markdown_node(node)
+    stmt = (
+        update(Node)
+        .where(Node.id == node_id, Node.version == expected_version)
+        .values(
+            payload=payload,
+            block_type=validated_bt.value,
+            version=Node.version + 1,
+            update_timestamp=datetime.now(UTC),
+        )
+    )
+    rowcount: int = session.execute(stmt).rowcount  # type: ignore[attr-defined]
+    if rowcount == 0:
+        session.expire(node)
+        raise NodeVersionConflictError(
+            node_id,
+            expected_version,
+            node.version,
+        )
+    session.expire_all()
+    node = session.get(Node, node_id)
+    assert node is not None
+    _touch_note(session, node.note_id)
     session.flush()
     return node
 

--- a/tests/api/test_nodes.py
+++ b/tests/api/test_nodes.py
@@ -6,6 +6,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from assistant.notes.service import (
+    add_markdown_node,
     add_text_node,
     create_note,
     create_notebook,
@@ -433,3 +434,105 @@ def test_delete_node_wrong_notebook(
         f"/notebook/{other_nb.id}/note/{note.id}/node/{node.id}",
     )
     assert response.status_code == 404
+
+
+# --- Markdown nodes ---
+
+
+def test_create_markdown_node(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node",
+        json={"payload": "# Title", "block_type": "heading"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["node_type"] == "markdown"
+    assert data["block_type"] == "heading"
+    assert data["payload"] == "# Title"
+
+
+def test_create_markdown_node_invalid_block_type(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node",
+        json={"payload": "text", "block_type": "invalid"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 422
+
+
+def test_update_markdown_node(
+    client: TestClient,
+    auth_headers: dict[str, str],  # noqa: ARG001
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    node = add_markdown_node(db_session, note.id, test_user.uid, "old", "paragraph")
+
+    response = client.patch(
+        f"/notebook/{nb.id}/note/{note.id}/node/{node.id}",
+        json={
+            "type": "update",
+            "payload": "# new heading",
+            "block_type": "heading",
+            "expected_version": 1,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["payload"] == "# new heading"
+    assert data["block_type"] == "heading"
+    assert data["version"] == 2
+
+
+def test_list_nodes_includes_block_type(
+    client: TestClient,
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    add_text_node(db_session, note.id, test_user.uid, "plain text")
+    add_markdown_node(db_session, note.id, test_user.uid, "# Title", "heading")
+
+    response = client.get(f"/notebook/{nb.id}/note/{note.id}/node")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["block_type"] is None
+    assert data[1]["block_type"] == "heading"
+
+
+def test_create_markdown_node_with_position(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    test_user: User,
+    db_session: Session,
+) -> None:
+    nb, note = _setup(db_session, test_user)
+    n1 = add_markdown_node(db_session, note.id, test_user.uid, "# H1", "heading")
+    add_markdown_node(db_session, note.id, test_user.uid, "para", "paragraph")
+
+    response = client.post(
+        f"/notebook/{nb.id}/note/{note.id}/node",
+        json={
+            "payload": "> quote",
+            "block_type": "blockquote",
+            "after_node_id": str(n1.id),
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    assert response.json()["block_type"] == "blockquote"

--- a/tests/notes/test_service.py
+++ b/tests/notes/test_service.py
@@ -15,6 +15,7 @@ from assistant.models.schema import (
     User,
 )
 from assistant.notes.exceptions import (
+    InvalidBlockTypeError,
     InvalidNodeTypeError,
     NodeNotFoundError,
     NodeVersionConflictError,
@@ -23,6 +24,7 @@ from assistant.notes.exceptions import (
 )
 from assistant.notes.service import (
     add_attachment_node,
+    add_markdown_node,
     add_text_node,
     create_note,
     create_notebook,
@@ -32,11 +34,13 @@ from assistant.notes.service import (
     get_note,
     get_notebook,
     get_ordered_nodes,
+    insert_markdown_node,
     insert_text_node,
     list_notebooks,
     list_notes,
     merge_text_nodes,
     split_text_node,
+    update_markdown_node,
     update_text_node,
 )
 
@@ -478,3 +482,119 @@ def test_update_touches_note_timestamp(db_session: Session) -> None:
     if updated_ts.tzinfo is not None:
         updated_ts = updated_ts.replace(tzinfo=None)
     assert updated_ts >= original_ts
+
+
+# -----------------------------------------------------------------------
+# Markdown node operations
+# -----------------------------------------------------------------------
+
+
+def test_add_markdown_node(db_session: Session) -> None:
+    user = _make_user(db_session)
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "N")
+
+    node = add_markdown_node(db_session, note.id, user.uid, "# Title", "heading")
+    assert node.node_type == NodeType.MARKDOWN
+    assert node.block_type == "heading"
+    assert node.payload == "# Title"
+    assert node.version == 1
+
+
+def test_add_markdown_node_invalid_block_type(db_session: Session) -> None:
+    user = _make_user(db_session)
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "N")
+
+    with pytest.raises(InvalidBlockTypeError):
+        add_markdown_node(db_session, note.id, user.uid, "text", "invalid_type")
+
+
+def test_insert_markdown_node_between(db_session: Session) -> None:
+    user = _make_user(db_session)
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "N")
+
+    n1 = add_markdown_node(db_session, note.id, user.uid, "# Title", "heading")
+    n3 = add_markdown_node(db_session, note.id, user.uid, "paragraph text", "paragraph")
+
+    n2 = insert_markdown_node(
+        db_session,
+        note.id,
+        user.uid,
+        "> quote",
+        "blockquote",
+        after_node_id=n1.id,
+        before_node_id=n3.id,
+    )
+
+    assert n1.position < n2.position < n3.position
+    assert n2.block_type == "blockquote"
+    nodes = get_ordered_nodes(db_session, note.id)
+    assert [n.payload for n in nodes] == ["# Title", "> quote", "paragraph text"]
+
+
+def test_update_markdown_node_success(db_session: Session) -> None:
+    user = _make_user(db_session)
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "N")
+    node = add_markdown_node(db_session, note.id, user.uid, "old", "paragraph")
+
+    updated = update_markdown_node(db_session, node.id, "# new heading", "heading", 1)
+    assert updated.payload == "# new heading"
+    assert updated.block_type == "heading"
+    assert updated.version == 2
+
+
+def test_update_markdown_node_version_conflict(db_session: Session) -> None:
+    user = _make_user(db_session)
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "N")
+    node = add_markdown_node(db_session, note.id, user.uid, "v1", "paragraph")
+
+    update_markdown_node(db_session, node.id, "v2", "paragraph", 1)
+
+    with pytest.raises(NodeVersionConflictError) as exc_info:
+        update_markdown_node(db_session, node.id, "v3", "paragraph", 1)
+    assert exc_info.value.expected_version == 1
+    assert exc_info.value.actual_version == 2
+
+
+def test_update_markdown_node_rejects_text_node(db_session: Session) -> None:
+    user = _make_user(db_session)
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "N")
+    node = add_text_node(db_session, note.id, user.uid, "text")
+
+    with pytest.raises(InvalidNodeTypeError):
+        update_markdown_node(db_session, node.id, "new", "paragraph", 1)
+
+
+def test_markdown_and_text_nodes_coexist(db_session: Session) -> None:
+    user = _make_user(db_session)
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "N")
+
+    add_text_node(db_session, note.id, user.uid, "plain text")
+    add_markdown_node(db_session, note.id, user.uid, "# Heading", "heading")
+    add_markdown_node(db_session, note.id, user.uid, "para", "paragraph")
+
+    nodes = get_ordered_nodes(db_session, note.id)
+    assert len(nodes) == 3
+    assert nodes[0].node_type == NodeType.TEXT
+    assert nodes[0].block_type is None
+    assert nodes[1].node_type == NodeType.MARKDOWN
+    assert nodes[1].block_type == "heading"
+    assert nodes[2].block_type == "paragraph"
+
+
+def test_delete_markdown_node(db_session: Session) -> None:
+    user = _make_user(db_session)
+    nb = create_notebook(db_session, "NB", user.uid)
+    note = create_note(db_session, nb.id, user.uid, "N")
+
+    node = add_markdown_node(db_session, note.id, user.uid, "# Title", "heading")
+    delete_node(db_session, node.id)
+
+    nodes = get_ordered_nodes(db_session, note.id)
+    assert len(nodes) == 0


### PR DESCRIPTION
## Summary

- **Backend**: Add `MARKDOWN` node type with `block_type` column (`heading`, `paragraph`, `blockquote`, `list_item`, `image`, `code_block`). New service functions (`add_markdown_node`, `insert_markdown_node`, `update_markdown_node`) with optimistic locking and validation. Updated API schemas, routes, and exception handlers.
- **Frontend**: Block-aware `NoteEditor` replaces the single-node editor. A doubly-linked list (`BlockList`) tracks blocks, maps cursor position to the current block, and handles incremental updates (typing updates block content, enter-enter splits, backspace-over-separator merges). On save, `executeSave` diffs blocks against server state — deleting removed nodes, converting TEXT→MARKDOWN nodes, creating new blocks, and updating dirty blocks.
- **Tooling**: `make dev-stop` target to kill backend (port 8000) and frontend (port 5173) dev servers.

## Test plan

- [x] `make check` passes (mypy, ruff, 119 backend tests including 13 new markdown node tests)
- [x] Frontend `tsc --noEmit` and `eslint` pass
- [x] API verified manually: create/update/list markdown nodes return correct `node_type` and `block_type`
- [ ] In the UI: create a new note, type multi-block markdown (heading, paragraph, list), save → verify DB has separate MARKDOWN nodes per block
- [ ] Existing TEXT-only notes still load and save correctly
- [ ] Reload after save → blocks load back from MARKDOWN nodes
- [ ] Edit a saved markdown note, change one block → only that block gets an update call

🤖 Generated with [Claude Code](https://claude.com/claude-code)