### PR TITLE
test: add Vitest test suite for frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.6",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.5.2",
@@ -22,10 +25,70 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.2.0",
+        "jsdom": "^29.1.1",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.34.0",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^4.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -261,6 +324,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -307,6 +380,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+      "integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -908,6 +1134,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1420,6 +1664,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.101.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
@@ -1445,6 +1696,104 @@
       "peerDependencies": {
         "react": "^18 || ^19"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1490,6 +1839,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1841,6 +2208,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1881,6 +2361,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1904,6 +2395,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1922,6 +2433,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1999,6 +2520,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2079,12 +2610,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2104,6 +2670,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2111,12 +2684,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.376",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
       "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2350,6 +2961,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2358,6 +2979,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2511,6 +3142,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2548,6 +3192,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2570,6 +3224,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2606,6 +3267,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2712,6 +3424,44 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2766,6 +3516,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -2831,6 +3595,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2850,6 +3627,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2910,6 +3694,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2941,6 +3755,14 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2971,6 +3793,30 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3028,6 +3874,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3073,6 +3932,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3081,6 +3947,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3109,6 +4002,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3124,6 +4041,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+      "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.3"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3188,6 +4161,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -3306,6 +4289,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3322,6 +4443,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3331,6 +4469,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,25 +7,32 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.80.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.6.2",
-    "@tanstack/react-query": "^5.80.7"
+    "react-router": "^7.6.2"
   },
   "devDependencies": {
-    "typescript": "~5.8.3",
+    "@eslint/js": "^9.28.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
-    "vite": "^6.3.5",
     "@vitejs/plugin-react": "^4.5.2",
     "eslint": "^9.28.0",
-    "@eslint/js": "^9.28.0",
-    "typescript-eslint": "^8.34.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
-    "globals": "^16.2.0"
+    "globals": "^16.2.0",
+    "jsdom": "^29.1.1",
+    "typescript": "~5.8.3",
+    "typescript-eslint": "^8.34.0",
+    "vite": "^6.3.5",
+    "vitest": "^4.1.9"
   }
 }

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import Layout from './Layout';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { Route, Routes } from 'react-router';
+
+vi.mock('./NotebookList', () => ({
+  default: () => <div data-testid="notebook-list">NotebookList</div>,
+}));
+
+vi.mock('./NoteList', () => ({
+  default: () => <div data-testid="note-list">NoteList</div>,
+}));
+
+vi.mock('./NoteEditor', () => ({
+  default: () => <div data-testid="note-editor">NoteEditor</div>,
+}));
+
+function renderLayout(path: string) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/notebooks" element={<Layout />} />
+      <Route path="/notebooks/:notebookId/notes" element={<Layout />} />
+      <Route path="/notebooks/:notebookId/notes/:noteId" element={<Layout />} />
+    </Routes>,
+    { initialEntries: [path] },
+  );
+}
+
+describe('Layout', () => {
+  it('renders NotebookList always', () => {
+    renderLayout('/notebooks');
+    expect(screen.getByTestId('notebook-list')).toBeInTheDocument();
+  });
+
+  it('shows placeholder when no notebook is selected', () => {
+    renderLayout('/notebooks');
+    expect(screen.getByText('Select a notebook to get started')).toBeInTheDocument();
+    expect(screen.queryByTestId('note-list')).not.toBeInTheDocument();
+  });
+
+  it('shows NoteList when notebook is selected', () => {
+    renderLayout('/notebooks/nb-1/notes');
+    expect(screen.getByTestId('note-list')).toBeInTheDocument();
+    expect(screen.getByText('Select a note to edit')).toBeInTheDocument();
+  });
+
+  it('shows NoteEditor when note is selected', () => {
+    renderLayout('/notebooks/nb-1/notes/note-1');
+    expect(screen.getByTestId('note-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('note-list')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/NoteList.test.tsx
+++ b/frontend/src/components/NoteList.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NoteList from './NoteList';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { Route, Routes } from 'react-router';
+
+vi.mock('../api/notes', () => ({
+  fetchNotes: vi.fn(),
+  createNote: vi.fn(),
+  deleteNote: vi.fn(),
+}));
+
+vi.mock('../contexts/UserContext', () => ({
+  useUser: () => ({ userId: 'test-user' }),
+}));
+
+import { fetchNotes, createNote, deleteNote } from '../api/notes';
+
+const mockFetchNotes = vi.mocked(fetchNotes);
+const mockCreateNote = vi.mocked(createNote);
+const mockDeleteNote = vi.mocked(deleteNote);
+
+function renderNoteList(path = '/notebooks/nb-1/notes') {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/notebooks/:notebookId/notes" element={<NoteList />} />
+      <Route path="/notebooks/:notebookId/notes/:noteId" element={<NoteList />} />
+    </Routes>,
+    { initialEntries: [path] },
+  );
+}
+
+describe('NoteList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing without notebookId', () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/" element={<NoteList />} />
+      </Routes>,
+      { initialEntries: ['/'] },
+    );
+    expect(screen.queryByText('Notes')).not.toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    mockFetchNotes.mockReturnValue(new Promise(() => {}));
+    renderNoteList();
+    expect(screen.getByText('Loading notes...')).toBeInTheDocument();
+  });
+
+  it('renders notes list', async () => {
+    mockFetchNotes.mockResolvedValue([
+      { id: 'note-1', notebook_id: 'nb-1', owner_id: 'test-user', title: 'First Note', creation_timestamp: '', update_timestamp: '' },
+      { id: 'note-2', notebook_id: 'nb-1', owner_id: 'test-user', title: 'Second Note', creation_timestamp: '', update_timestamp: '' },
+    ]);
+    renderNoteList();
+
+    await waitFor(() => {
+      expect(screen.getByText('First Note')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Second Note')).toBeInTheDocument();
+  });
+
+  it('shows empty state', async () => {
+    mockFetchNotes.mockResolvedValue([]);
+    renderNoteList();
+
+    await waitFor(() => {
+      expect(screen.getByText('No notes yet')).toBeInTheDocument();
+    });
+  });
+
+  it('creates a note on form submit', async () => {
+    const user = userEvent.setup();
+    mockFetchNotes.mockResolvedValue([]);
+    mockCreateNote.mockResolvedValue({
+      id: 'note-new', notebook_id: 'nb-1', owner_id: 'test-user',
+      title: 'My Note', creation_timestamp: '', update_timestamp: '',
+    });
+
+    renderNoteList();
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('New note title')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText('New note title'), 'My Note');
+    await user.click(screen.getByText('Create'));
+
+    await waitFor(() => {
+      expect(mockCreateNote).toHaveBeenCalledWith('test-user', 'nb-1', 'My Note');
+    });
+  });
+
+  it('deletes a note when delete button is clicked', async () => {
+    const user = userEvent.setup();
+    mockFetchNotes.mockResolvedValue([
+      { id: 'note-1', notebook_id: 'nb-1', owner_id: 'test-user', title: 'Delete Me', creation_timestamp: '', update_timestamp: '' },
+    ]);
+    mockDeleteNote.mockResolvedValue(undefined);
+
+    renderNoteList();
+    await waitFor(() => {
+      expect(screen.getByText('Delete Me')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTitle('Delete note'));
+
+    await waitFor(() => {
+      expect(mockDeleteNote).toHaveBeenCalledWith('nb-1', 'note-1');
+    });
+  });
+});

--- a/frontend/src/components/NotebookList.test.tsx
+++ b/frontend/src/components/NotebookList.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NotebookList from './NotebookList';
+import { renderWithProviders } from '../test/renderWithProviders';
+
+vi.mock('../api/notebooks', () => ({
+  fetchNotebooks: vi.fn(),
+  createNotebook: vi.fn(),
+  deleteNotebook: vi.fn(),
+}));
+
+vi.mock('../contexts/UserContext', () => ({
+  useUser: () => ({ userId: 'test-user' }),
+}));
+
+import { fetchNotebooks, createNotebook, deleteNotebook } from '../api/notebooks';
+
+const mockFetch = vi.mocked(fetchNotebooks);
+const mockCreate = vi.mocked(createNotebook);
+const mockDelete = vi.mocked(deleteNotebook);
+
+describe('NotebookList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<NotebookList />);
+    expect(screen.getByText('Loading notebooks...')).toBeInTheDocument();
+  });
+
+  it('renders notebook list', async () => {
+    mockFetch.mockResolvedValue([
+      { id: 'nb-1', name: 'My Notebook', owner_id: 'test-user' },
+      { id: 'nb-2', name: 'Work Notes', owner_id: 'test-user' },
+    ]);
+    renderWithProviders(<NotebookList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Notebook')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Work Notes')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no notebooks', async () => {
+    mockFetch.mockResolvedValue([]);
+    renderWithProviders(<NotebookList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No notebooks yet')).toBeInTheDocument();
+    });
+  });
+
+  it('creates a notebook on form submit', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValue([]);
+    mockCreate.mockResolvedValue({ id: 'nb-new', name: 'New NB', owner_id: 'test-user' });
+
+    renderWithProviders(<NotebookList />);
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('New notebook name')).toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText('New notebook name');
+    await user.type(input, 'New NB');
+    await user.click(screen.getByText('Create'));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('test-user', 'New NB');
+    });
+  });
+
+  it('disables create button when input is empty', async () => {
+    mockFetch.mockResolvedValue([]);
+    renderWithProviders(<NotebookList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+  });
+
+  it('calls delete when delete button is clicked', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValue([
+      { id: 'nb-1', name: 'To Delete', owner_id: 'test-user' },
+    ]);
+    mockDelete.mockResolvedValue(undefined);
+
+    renderWithProviders(<NotebookList />);
+    await waitFor(() => {
+      expect(screen.getByText('To Delete')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTitle('Delete notebook'));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith('nb-1');
+    });
+  });
+
+  it('highlights active notebook', async () => {
+    mockFetch.mockResolvedValue([
+      { id: 'nb-1', name: 'Active NB', owner_id: 'test-user' },
+    ]);
+    renderWithProviders(<NotebookList />, {
+      initialEntries: ['/notebooks/nb-1/notes'],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Active NB')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/markdown/blockList.test.ts
+++ b/frontend/src/markdown/blockList.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect } from 'vitest';
+import { BlockList } from './blockList';
+import type { NoteNode } from '../types';
+
+function makeNode(overrides: Partial<NoteNode> = {}): NoteNode {
+  return {
+    id: 'node-1',
+    note_id: 'note-1',
+    author_id: 'user-1',
+    node_type: 'markdown',
+    payload: 'hello',
+    block_type: 'paragraph',
+    version: 1,
+    update_timestamp: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('BlockList', () => {
+  describe('buildFromText', () => {
+    it('builds blocks from simple text', () => {
+      const bl = new BlockList();
+      bl.buildFromText('hello world');
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].content).toBe('hello world');
+      expect(blocks[0].blockType).toBe('paragraph');
+      expect(blocks[0].dirty).toBe(true);
+      expect(blocks[0].serverState).toBeNull();
+    });
+
+    it('builds multiple blocks separated by blank lines', () => {
+      const bl = new BlockList();
+      bl.buildFromText('# Title\n\nParagraph text');
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].blockType).toBe('heading');
+      expect(blocks[1].blockType).toBe('paragraph');
+    });
+
+    it('sets correct line starts', () => {
+      const bl = new BlockList();
+      bl.buildFromText('line1\n\nline2\nline3');
+      const blocks = bl.toArray();
+      expect(blocks[0].lineStart).toBe(0);
+      expect(blocks[0].lineCount).toBe(1);
+      expect(blocks[1].lineStart).toBe(2); // +1 for separator line
+      expect(blocks[1].lineCount).toBe(2);
+    });
+
+    it('resets state on rebuild', () => {
+      const bl = new BlockList();
+      bl.buildFromText('first');
+      bl.deletedNodeIds.push('old-id');
+      bl.buildFromText('second');
+      expect(bl.toArray()).toHaveLength(1);
+      expect(bl.toArray()[0].content).toBe('second');
+      expect(bl.deletedNodeIds).toEqual([]);
+    });
+  });
+
+  describe('buildFromServerNodes', () => {
+    it('builds from markdown nodes', () => {
+      const bl = new BlockList();
+      bl.buildFromServerNodes([
+        makeNode({ id: 'n1', payload: '# Title', block_type: 'heading' }),
+        makeNode({ id: 'n2', payload: 'Body text', block_type: 'paragraph' }),
+      ]);
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].serverState).toEqual({ nodeId: 'n1', version: 1, nodeType: 'markdown' });
+      expect(blocks[0].dirty).toBe(false);
+      expect(blocks[1].serverState).toEqual({ nodeId: 'n2', version: 1, nodeType: 'markdown' });
+    });
+
+    it('splits text nodes into multiple blocks', () => {
+      const bl = new BlockList();
+      bl.buildFromServerNodes([
+        makeNode({ id: 'n1', node_type: 'text', payload: '# Title\n\nBody text', block_type: null }),
+      ]);
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].serverState).toEqual({ nodeId: 'n1', version: 1, nodeType: 'text' });
+      expect(blocks[0].dirty).toBe(false);
+      expect(blocks[1].serverState).toBeNull();
+      expect(blocks[1].dirty).toBe(true);
+    });
+
+    it('handles null payload as empty string', () => {
+      const bl = new BlockList();
+      bl.buildFromServerNodes([makeNode({ payload: null })]);
+      const blocks = bl.toArray();
+      expect(blocks[0].content).toBe('');
+    });
+  });
+
+  describe('toText', () => {
+    it('joins blocks with double newlines', () => {
+      const bl = new BlockList();
+      bl.buildFromText('first\n\nsecond\n\nthird');
+      expect(bl.toText()).toBe('first\n\nsecond\n\nthird');
+    });
+
+    it('returns empty for single empty block', () => {
+      const bl = new BlockList();
+      bl.buildFromText('');
+      expect(bl.toText()).toBe('');
+    });
+  });
+
+  describe('getBlockAtLine', () => {
+    it('returns block containing the given line', () => {
+      const bl = new BlockList();
+      bl.buildFromText('line0\n\nline2\nline3');
+      // block0: lineStart=0, lineCount=1 (line 0)
+      // block1: lineStart=2, lineCount=2 (lines 2, 3)
+      expect(bl.getBlockAtLine(0)?.content).toBe('line0');
+      expect(bl.getBlockAtLine(2)?.content).toBe('line2\nline3');
+      expect(bl.getBlockAtLine(3)?.content).toBe('line2\nline3');
+    });
+
+    it('returns tail for lines beyond the last block', () => {
+      const bl = new BlockList();
+      bl.buildFromText('only');
+      expect(bl.getBlockAtLine(100)?.content).toBe('only');
+    });
+
+    it('returns null for empty list', () => {
+      const bl = new BlockList();
+      expect(bl.getBlockAtLine(0)).toBeNull();
+    });
+  });
+
+  describe('insertAfter', () => {
+    it('inserts at head when after is null', () => {
+      const bl = new BlockList();
+      bl.buildFromText('existing');
+      bl.insertAfter(null, 'heading', '# New');
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].content).toBe('# New');
+      expect(blocks[1].content).toBe('existing');
+    });
+
+    it('inserts after a given block', () => {
+      const bl = new BlockList();
+      bl.buildFromText('first\n\nthird');
+      const first = bl.head!;
+      bl.insertAfter(first, 'paragraph', 'second');
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(3);
+      expect(blocks[0].content).toBe('first');
+      expect(blocks[1].content).toBe('second');
+      expect(blocks[2].content).toBe('third');
+    });
+
+    it('inserts at the end when after is tail', () => {
+      const bl = new BlockList();
+      bl.buildFromText('first');
+      bl.insertAfter(bl.tail!, 'paragraph', 'last');
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[1].content).toBe('last');
+      expect(bl.tail?.content).toBe('last');
+    });
+
+    it('marks inserted block as dirty', () => {
+      const bl = new BlockList();
+      bl.buildFromText('existing');
+      const inserted = bl.insertAfter(bl.head, 'paragraph', 'new');
+      expect(inserted.dirty).toBe(true);
+      expect(inserted.serverState).toBeNull();
+    });
+
+    it('recomputes line starts after insertion', () => {
+      const bl = new BlockList();
+      bl.buildFromText('a\n\nb');
+      bl.insertAfter(bl.head!, 'paragraph', 'middle');
+      const blocks = bl.toArray();
+      expect(blocks[0].lineStart).toBe(0);
+      expect(blocks[1].lineStart).toBe(2);
+      expect(blocks[2].lineStart).toBe(4);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes head block', () => {
+      const bl = new BlockList();
+      bl.buildFromText('first\n\nsecond');
+      bl.remove(bl.head!);
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].content).toBe('second');
+      expect(bl.head?.content).toBe('second');
+    });
+
+    it('removes tail block', () => {
+      const bl = new BlockList();
+      bl.buildFromText('first\n\nsecond');
+      bl.remove(bl.tail!);
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].content).toBe('first');
+      expect(bl.tail?.content).toBe('first');
+    });
+
+    it('removes middle block', () => {
+      const bl = new BlockList();
+      bl.buildFromText('first\n\nsecond\n\nthird');
+      const middle = bl.toArray()[1];
+      bl.remove(middle);
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].content).toBe('first');
+      expect(blocks[1].content).toBe('third');
+    });
+
+    it('tracks deleted server node ids', () => {
+      const bl = new BlockList();
+      bl.buildFromServerNodes([
+        makeNode({ id: 'n1', payload: 'first' }),
+        makeNode({ id: 'n2', payload: 'second' }),
+      ]);
+      bl.remove(bl.head!);
+      expect(bl.deletedNodeIds).toEqual(['n1']);
+    });
+
+    it('does not track deletion for blocks without server state', () => {
+      const bl = new BlockList();
+      bl.buildFromText('no server state');
+      bl.remove(bl.head!);
+      expect(bl.deletedNodeIds).toEqual([]);
+    });
+  });
+
+  describe('updateBlock', () => {
+    it('updates content, lineCount, blockType, and dirty flag', () => {
+      const bl = new BlockList();
+      bl.buildFromServerNodes([makeNode({ id: 'n1', payload: 'old', block_type: 'paragraph' })]);
+      const block = bl.head!;
+      expect(block.dirty).toBe(false);
+
+      bl.updateBlock(block, '# New heading');
+      expect(block.content).toBe('# New heading');
+      expect(block.blockType).toBe('heading');
+      expect(block.dirty).toBe(true);
+      expect(block.lineCount).toBe(1);
+    });
+
+    it('handles multiline content', () => {
+      const bl = new BlockList();
+      bl.buildFromText('single');
+      bl.updateBlock(bl.head!, 'line1\nline2\nline3');
+      expect(bl.head!.lineCount).toBe(3);
+    });
+  });
+
+  describe('splitBlock', () => {
+    it('splits a block at the given line offset', () => {
+      const bl = new BlockList();
+      bl.buildFromText('line0\nline1\nline2');
+      bl.splitBlock(bl.head!, 1);
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].content).toBe('line0');
+      expect(blocks[1].content).toBe('line1\nline2');
+    });
+
+    it('marks both blocks as dirty', () => {
+      const bl = new BlockList();
+      bl.buildFromServerNodes([makeNode({ payload: 'a\nb' })]);
+      const newBlock = bl.splitBlock(bl.head!, 1);
+      expect(bl.head!.dirty).toBe(true);
+      expect(newBlock.dirty).toBe(true);
+    });
+
+    it('reclassifies block types after split', () => {
+      const bl = new BlockList();
+      bl.buildFromText('# heading\nparagraph text');
+      bl.splitBlock(bl.head!, 1);
+      const blocks = bl.toArray();
+      expect(blocks[0].blockType).toBe('heading');
+      expect(blocks[1].blockType).toBe('paragraph');
+    });
+  });
+
+  describe('mergeWithNext', () => {
+    it('merges two adjacent blocks', () => {
+      const bl = new BlockList();
+      bl.buildFromText('first\n\nsecond');
+      bl.mergeWithNext(bl.head!);
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].content).toBe('first\nsecond');
+      expect(blocks[0].dirty).toBe(true);
+    });
+
+    it('does nothing if block has no next', () => {
+      const bl = new BlockList();
+      bl.buildFromText('only');
+      bl.mergeWithNext(bl.head!);
+      expect(bl.toArray()).toHaveLength(1);
+      expect(bl.head!.content).toBe('only');
+    });
+
+    it('tracks deletion of merged server-backed block', () => {
+      const bl = new BlockList();
+      bl.buildFromServerNodes([
+        makeNode({ id: 'n1', payload: 'first' }),
+        makeNode({ id: 'n2', payload: 'second' }),
+      ]);
+      bl.mergeWithNext(bl.head!);
+      expect(bl.deletedNodeIds).toEqual(['n2']);
+    });
+  });
+
+  describe('totalLines', () => {
+    it('returns 0 for empty list', () => {
+      const bl = new BlockList();
+      expect(bl.totalLines()).toBe(0);
+    });
+
+    it('returns correct count for single block', () => {
+      const bl = new BlockList();
+      bl.buildFromText('line1\nline2');
+      expect(bl.totalLines()).toBe(2);
+    });
+
+    it('includes separator lines between blocks', () => {
+      const bl = new BlockList();
+      bl.buildFromText('a\n\nb');
+      // block0: lineStart=0, lineCount=1
+      // block1: lineStart=2, lineCount=1
+      // total = 2 + 1 = 3
+      expect(bl.totalLines()).toBe(3);
+    });
+  });
+
+  describe('linked list integrity', () => {
+    it('maintains prev/next pointers correctly', () => {
+      const bl = new BlockList();
+      bl.buildFromText('a\n\nb\n\nc');
+      const blocks = bl.toArray();
+      expect(blocks[0].prev).toBeNull();
+      expect(blocks[0].next).toBe(blocks[1]);
+      expect(blocks[1].prev).toBe(blocks[0]);
+      expect(blocks[1].next).toBe(blocks[2]);
+      expect(blocks[2].prev).toBe(blocks[1]);
+      expect(blocks[2].next).toBeNull();
+      expect(bl.head).toBe(blocks[0]);
+      expect(bl.tail).toBe(blocks[2]);
+    });
+
+    it('maintains integrity after insert and remove', () => {
+      const bl = new BlockList();
+      bl.buildFromText('a\n\nc');
+      bl.insertAfter(bl.head!, 'paragraph', 'b');
+      bl.remove(bl.toArray()[1]); // remove 'b'
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].next).toBe(blocks[1]);
+      expect(blocks[1].prev).toBe(blocks[0]);
+    });
+  });
+});

--- a/frontend/src/markdown/parser.test.ts
+++ b/frontend/src/markdown/parser.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { classifyBlockType, parseMarkdownBlocks } from './parser';
+
+describe('classifyBlockType', () => {
+  it('identifies headings', () => {
+    expect(classifyBlockType('# Title')).toBe('heading');
+    expect(classifyBlockType('## Subtitle')).toBe('heading');
+    expect(classifyBlockType('###### Deep heading')).toBe('heading');
+  });
+
+  it('requires a space after hash marks', () => {
+    expect(classifyBlockType('#NoSpace')).toBe('paragraph');
+  });
+
+  it('identifies blockquotes', () => {
+    expect(classifyBlockType('> quoted text')).toBe('blockquote');
+    expect(classifyBlockType('>compact quote')).toBe('blockquote');
+  });
+
+  it('identifies unordered list items', () => {
+    expect(classifyBlockType('- item')).toBe('list_item');
+    expect(classifyBlockType('* item')).toBe('list_item');
+    expect(classifyBlockType('+ item')).toBe('list_item');
+  });
+
+  it('identifies ordered list items', () => {
+    expect(classifyBlockType('1. first')).toBe('list_item');
+    expect(classifyBlockType('42. forty-second')).toBe('list_item');
+  });
+
+  it('identifies images', () => {
+    expect(classifyBlockType('![alt](url.png)')).toBe('image');
+  });
+
+  it('identifies code blocks', () => {
+    expect(classifyBlockType('```js\nconsole.log("hi")\n```')).toBe('code_block');
+    expect(classifyBlockType('```')).toBe('code_block');
+  });
+
+  it('defaults to paragraph', () => {
+    expect(classifyBlockType('just some text')).toBe('paragraph');
+    expect(classifyBlockType('')).toBe('paragraph');
+  });
+
+  it('classifies based on first line only', () => {
+    expect(classifyBlockType('# heading\nsome paragraph text')).toBe('heading');
+  });
+
+  it('handles leading whitespace on the first line', () => {
+    expect(classifyBlockType('  # heading')).toBe('heading');
+    expect(classifyBlockType('  > quote')).toBe('blockquote');
+  });
+});
+
+describe('parseMarkdownBlocks', () => {
+  it('returns a single empty paragraph for empty string', () => {
+    const blocks = parseMarkdownBlocks('');
+    expect(blocks).toEqual([
+      { blockType: 'paragraph', content: '', lineCount: 1 },
+    ]);
+  });
+
+  it('parses a single paragraph', () => {
+    const blocks = parseMarkdownBlocks('hello world');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({
+      blockType: 'paragraph',
+      content: 'hello world',
+      lineCount: 1,
+    });
+  });
+
+  it('parses multiple paragraphs separated by blank lines', () => {
+    const blocks = parseMarkdownBlocks('first paragraph\n\nsecond paragraph');
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].content).toBe('first paragraph');
+    expect(blocks[1].content).toBe('second paragraph');
+  });
+
+  it('parses a heading block', () => {
+    const blocks = parseMarkdownBlocks('# My Title');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].blockType).toBe('heading');
+  });
+
+  it('parses mixed block types', () => {
+    const text = '# Title\n\nSome paragraph\n\n> A quote\n\n- item 1\n- item 2';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(4);
+    expect(blocks[0].blockType).toBe('heading');
+    expect(blocks[1].blockType).toBe('paragraph');
+    expect(blocks[2].blockType).toBe('blockquote');
+    expect(blocks[3].blockType).toBe('list_item');
+  });
+
+  it('treats consecutive non-blank lines as one block', () => {
+    const text = 'line one\nline two\nline three';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].content).toBe('line one\nline two\nline three');
+    expect(blocks[0].lineCount).toBe(3);
+  });
+
+  it('parses a fenced code block', () => {
+    const text = '```js\nconst x = 1;\nconsole.log(x);\n```';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].blockType).toBe('code_block');
+    expect(blocks[0].lineCount).toBe(4);
+  });
+
+  it('parses code block with surrounding text', () => {
+    const text = 'before\n\n```\ncode\n```\n\nafter';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].blockType).toBe('paragraph');
+    expect(blocks[1].blockType).toBe('code_block');
+    expect(blocks[2].blockType).toBe('paragraph');
+  });
+
+  it('handles unclosed code block', () => {
+    const text = '```\ncode without closing';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].blockType).toBe('code_block');
+    expect(blocks[0].content).toBe('```\ncode without closing');
+  });
+
+  it('handles multiple blank lines between blocks', () => {
+    const text = 'first\n\n\n\nsecond';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].content).toBe('first');
+    expect(blocks[1].content).toBe('second');
+  });
+
+  it('handles only blank lines', () => {
+    const text = '\n\n\n';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ blockType: 'paragraph', content: '', lineCount: 1 });
+  });
+});

--- a/frontend/src/markdown/reconcile.test.ts
+++ b/frontend/src/markdown/reconcile.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BlockList } from './blockList';
+import { executeSave } from './reconcile';
+import type { NoteNode } from '../types';
+
+vi.mock('../api/nodes', () => ({
+  createNode: vi.fn(),
+  updateNode: vi.fn(),
+  deleteNode: vi.fn(),
+}));
+
+import { createNode, updateNode, deleteNode } from '../api/nodes';
+
+const mockCreateNode = vi.mocked(createNode);
+const mockUpdateNode = vi.mocked(updateNode);
+const mockDeleteNode = vi.mocked(deleteNode);
+
+function makeServerNode(overrides: Partial<NoteNode> = {}): NoteNode {
+  return {
+    id: 'created-1',
+    note_id: 'note-1',
+    author_id: 'user-1',
+    node_type: 'markdown',
+    payload: '',
+    block_type: 'paragraph',
+    version: 1,
+    update_timestamp: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('executeSave', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateNode.mockResolvedValue(makeServerNode());
+    mockUpdateNode.mockResolvedValue(makeServerNode({ version: 2 }));
+    mockDeleteNode.mockResolvedValue(undefined);
+  });
+
+  it('creates new blocks that have no server state', async () => {
+    const bl = new BlockList();
+    bl.buildFromText('new content');
+
+    await executeSave('nb-1', 'note-1', bl, 'user-1');
+
+    expect(mockCreateNode).toHaveBeenCalledOnce();
+    expect(mockCreateNode).toHaveBeenCalledWith('nb-1', 'note-1', 'new content', {
+      blockType: 'paragraph',
+      afterNodeId: undefined,
+      beforeNodeId: undefined,
+      userId: 'user-1',
+    });
+  });
+
+  it('updates dirty blocks that have server state', async () => {
+    const bl = new BlockList();
+    bl.buildFromServerNodes([
+      makeServerNode({ id: 'n1', payload: 'old', version: 3 }),
+    ]);
+    bl.updateBlock(bl.head!, 'updated content');
+
+    await executeSave('nb-1', 'note-1', bl, 'user-1');
+
+    expect(mockUpdateNode).toHaveBeenCalledOnce();
+    expect(mockUpdateNode).toHaveBeenCalledWith(
+      'nb-1', 'note-1', 'n1', 'updated content', 3, 'paragraph',
+    );
+  });
+
+  it('deletes removed blocks', async () => {
+    const bl = new BlockList();
+    bl.buildFromServerNodes([
+      makeServerNode({ id: 'n1', payload: 'first' }),
+      makeServerNode({ id: 'n2', payload: 'second' }),
+    ]);
+    bl.remove(bl.tail!);
+
+    await executeSave('nb-1', 'note-1', bl, 'user-1');
+
+    expect(mockDeleteNode).toHaveBeenCalledWith('nb-1', 'note-1', 'n2');
+    expect(bl.deletedNodeIds).toEqual([]);
+  });
+
+  it('replaces text nodes with markdown nodes', async () => {
+    const bl = new BlockList();
+    bl.buildFromServerNodes([
+      makeServerNode({ id: 'text-1', node_type: 'text', payload: 'content', block_type: null }),
+    ]);
+    bl.updateBlock(bl.head!, 'updated');
+
+    await executeSave('nb-1', 'note-1', bl, 'user-1');
+
+    expect(mockDeleteNode).toHaveBeenCalledWith('nb-1', 'note-1', 'text-1');
+    expect(mockCreateNode).toHaveBeenCalled();
+  });
+
+  it('does not call APIs for clean blocks', async () => {
+    const bl = new BlockList();
+    bl.buildFromServerNodes([
+      makeServerNode({ id: 'n1', payload: 'unchanged' }),
+    ]);
+
+    await executeSave('nb-1', 'note-1', bl, 'user-1');
+
+    expect(mockCreateNode).not.toHaveBeenCalled();
+    expect(mockUpdateNode).not.toHaveBeenCalled();
+    expect(mockDeleteNode).not.toHaveBeenCalled();
+  });
+
+  it('passes correct afterNodeId for sequenced creates', async () => {
+    mockCreateNode.mockResolvedValueOnce(makeServerNode({ id: 'created-1', version: 1 }));
+    mockCreateNode.mockResolvedValueOnce(makeServerNode({ id: 'created-2', version: 1 }));
+
+    const bl = new BlockList();
+    bl.buildFromText('first\n\nsecond');
+
+    await executeSave('nb-1', 'note-1', bl, 'user-1');
+
+    expect(mockCreateNode).toHaveBeenCalledTimes(2);
+    const firstCallOpts = mockCreateNode.mock.calls[0][3];
+    expect(firstCallOpts.afterNodeId).toBeUndefined();
+
+    const secondCallOpts = mockCreateNode.mock.calls[1][3];
+    expect(secondCallOpts.afterNodeId).toBe('created-1');
+  });
+
+  it('updates server state on blocks after create', async () => {
+    mockCreateNode.mockResolvedValue(makeServerNode({ id: 'new-id', version: 5 }));
+
+    const bl = new BlockList();
+    bl.buildFromText('new');
+
+    await executeSave('nb-1', 'note-1', bl, 'user-1');
+
+    const block = bl.head!;
+    expect(block.serverState).toEqual({ nodeId: 'new-id', version: 5, nodeType: 'markdown' });
+    expect(block.dirty).toBe(false);
+  });
+
+  it('updates version on blocks after update', async () => {
+    mockUpdateNode.mockResolvedValue(makeServerNode({ version: 10 }));
+
+    const bl = new BlockList();
+    bl.buildFromServerNodes([makeServerNode({ id: 'n1', version: 3 })]);
+    bl.updateBlock(bl.head!, 'changed');
+
+    await executeSave('nb-1', 'note-1', bl, 'user-1');
+
+    expect(bl.head!.serverState!.version).toBe(10);
+    expect(bl.head!.dirty).toBe(false);
+  });
+});

--- a/frontend/src/test/renderWithProviders.tsx
+++ b/frontend/src/test/renderWithProviders.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import type { ReactElement } from 'react';
+
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    initialEntries = ['/'],
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    }),
+  }: {
+    initialEntries?: string[];
+    queryClient?: QueryClient;
+  } = {},
+) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        {ui}
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,4 +3,8 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+  },
 })


### PR DESCRIPTION
## Summary
- Set up Vitest with jsdom, `@testing-library/react`, `@testing-library/user-event`, and `@testing-library/jest-dom`
- Added 81 tests across 6 test files covering the markdown module (`parser`, `blockList`, `reconcile`) and React components (`Layout`, `NotebookList`, `NoteList`)
- Added `test` and `test:watch` npm scripts

## Test plan
- [x] `npm test` passes all 81 tests
- [ ] Verify CI runs the test suite successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)