### PR TITLE
fix: split markdown blocks at element boundaries

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router';
 import { fetchNodes } from '../api/nodes';
 import { BlockList } from '../markdown/blockList';
 import type { BlockNode } from '../markdown/blockList';
+import { parseMarkdownBlocks } from '../markdown/parser';
 import { executeSave } from '../markdown/reconcile';
 import { useUser } from '../contexts/UserContext';
 
@@ -90,6 +91,19 @@ export default function NoteEditor() {
 
       const rebuilt = bl.toText();
       setText(rebuilt);
+      setStatus(null);
+      return;
+    }
+
+    const parsed = parseMarkdownBlocks(blockContent);
+    if (parsed.length > 1) {
+      bl.updateBlock(currentBlock, parsed[0].content);
+      let after = currentBlock;
+      for (let k = 1; k < parsed.length; k++) {
+        after = bl.insertAfter(after, parsed[k].blockType, parsed[k].content);
+      }
+      currentBlockRef.current = bl.getBlockAtLine(cursorLine);
+      setText(bl.toText());
       setStatus(null);
       return;
     }

--- a/frontend/src/markdown/blockList.test.ts
+++ b/frontend/src/markdown/blockList.test.ts
@@ -86,6 +86,22 @@ describe('BlockList', () => {
       expect(blocks[1].dirty).toBe(true);
     });
 
+    it('splits text nodes containing consecutive list items', () => {
+      const bl = new BlockList();
+      bl.buildFromServerNodes([
+        makeNode({ id: 'n1', node_type: 'text', payload: '- first\n- second', block_type: null }),
+      ]);
+      const blocks = bl.toArray();
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].content).toBe('- first');
+      expect(blocks[0].blockType).toBe('list_item');
+      expect(blocks[0].serverState).toEqual({ nodeId: 'n1', version: 1, nodeType: 'text' });
+      expect(blocks[1].content).toBe('- second');
+      expect(blocks[1].blockType).toBe('list_item');
+      expect(blocks[1].serverState).toBeNull();
+      expect(blocks[1].dirty).toBe(true);
+    });
+
     it('handles null payload as empty string', () => {
       const bl = new BlockList();
       bl.buildFromServerNodes([makeNode({ payload: null })]);

--- a/frontend/src/markdown/parser.test.ts
+++ b/frontend/src/markdown/parser.test.ts
@@ -86,19 +86,49 @@ describe('parseMarkdownBlocks', () => {
   it('parses mixed block types', () => {
     const text = '# Title\n\nSome paragraph\n\n> A quote\n\n- item 1\n- item 2';
     const blocks = parseMarkdownBlocks(text);
-    expect(blocks).toHaveLength(4);
+    expect(blocks).toHaveLength(5);
     expect(blocks[0].blockType).toBe('heading');
     expect(blocks[1].blockType).toBe('paragraph');
     expect(blocks[2].blockType).toBe('blockquote');
     expect(blocks[3].blockType).toBe('list_item');
+    expect(blocks[3].content).toBe('- item 1');
+    expect(blocks[4].blockType).toBe('list_item');
+    expect(blocks[4].content).toBe('- item 2');
   });
 
-  it('treats consecutive non-blank lines as one block', () => {
+  it('treats consecutive non-blank paragraph lines as one block', () => {
     const text = 'line one\nline two\nline three';
     const blocks = parseMarkdownBlocks(text);
     expect(blocks).toHaveLength(1);
     expect(blocks[0].content).toBe('line one\nline two\nline three');
     expect(blocks[0].lineCount).toBe(3);
+  });
+
+  it('splits consecutive list items without blank line', () => {
+    const text = '- first\n- second\n- third';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]).toEqual({ blockType: 'list_item', content: '- first', lineCount: 1 });
+    expect(blocks[1]).toEqual({ blockType: 'list_item', content: '- second', lineCount: 1 });
+    expect(blocks[2]).toEqual({ blockType: 'list_item', content: '- third', lineCount: 1 });
+  });
+
+  it('splits heading from following text without blank line', () => {
+    const text = '# Title\nsome paragraph text';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].blockType).toBe('heading');
+    expect(blocks[0].content).toBe('# Title');
+    expect(blocks[1].blockType).toBe('paragraph');
+    expect(blocks[1].content).toBe('some paragraph text');
+  });
+
+  it('keeps blockquote continuation lines as one block', () => {
+    const text = '> line one\n> line two';
+    const blocks = parseMarkdownBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].blockType).toBe('blockquote');
+    expect(blocks[0].content).toBe('> line one\n> line two');
   });
 
   it('parses a fenced code block', () => {

--- a/frontend/src/markdown/parser.ts
+++ b/frontend/src/markdown/parser.ts
@@ -16,6 +16,14 @@ export function classifyBlockType(content: string): MarkdownBlockType {
   return 'paragraph';
 }
 
+function startsNewBlock(line: string): boolean {
+  const trimmed = line.trimStart();
+  if (/^#{1,6}\s/.test(trimmed)) return true;
+  if (/^[-*+]\s/.test(trimmed) || /^\d+\.\s/.test(trimmed)) return true;
+  if (trimmed.startsWith('![')) return true;
+  return false;
+}
+
 export function parseMarkdownBlocks(text: string): ParsedBlock[] {
   if (text === '') {
     return [{ blockType: 'paragraph', content: '', lineCount: 1 }];
@@ -43,8 +51,13 @@ export function parseMarkdownBlocks(text: string): ParsedBlock[] {
     }
 
     const startLine = i;
-    while (i < lines.length && lines[i] !== '' && !lines[i].startsWith('```')) {
-      i++;
+    const firstLineType = classifyBlockType(lines[i]);
+    i++;
+    if (firstLineType !== 'heading' && firstLineType !== 'image') {
+      while (i < lines.length && lines[i] !== '' && !lines[i].startsWith('```')) {
+        if (startsNewBlock(lines[i])) break;
+        i++;
+      }
     }
 
     if (i > startLine) {


### PR DESCRIPTION
## Summary
- **Parser fix**: `parseMarkdownBlocks` now splits at block-level element boundaries (headings, list items, images) even without a blank line between them. Previously `- bullet1\n- bullet2` was treated as one block.
- **Editor fix**: `handleTextChange` re-parses block content after edits to detect intra-block splits beyond the existing `\n\n` check, so typing a new list item within a block correctly creates a separate node.
- Tests updated to cover consecutive list items, heading-before-paragraph, and blockquote continuation.

## Test plan
- [x] Unit tests: all 85 frontend tests pass (`npx vitest run`)
- [x] Scenario 1: Create note with heading + paragraph + bullet → 3 nodes saved correctly
- [x] Scenario 2: Change heading to paragraph → block_type updated, 2 nodes preserved
- [x] Scenario 3: Insert bullet between existing bullets (type-first approach) → 4 nodes in correct order
- [x] Scenario 4: Split multiline paragraph with Enter Enter → 6 nodes after split
- [x] Backend tests: no regressions (4 pre-existing failures in unrelated modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)