### PR TITLE
feat: add debug view panel for block list visualization

### DIFF
--- a/frontend/src/components/DebugBlockView.tsx
+++ b/frontend/src/components/DebugBlockView.tsx
@@ -1,0 +1,61 @@
+import type { MarkdownBlockType } from '../types';
+
+export interface DebugBlockSnapshot {
+  index: number;
+  blockType: MarkdownBlockType;
+  content: string;
+  lineStart: number;
+  lineCount: number;
+  dirty: boolean;
+  hasServerState: boolean;
+  nodeId: string | null;
+  version: number | null;
+  isCurrent: boolean;
+}
+
+interface DebugBlockViewProps {
+  blocks: DebugBlockSnapshot[];
+}
+
+export default function DebugBlockView({ blocks }: DebugBlockViewProps) {
+  return (
+    <div className="debug-panel">
+      <div className="debug-panel-header">
+        Block List ({blocks.length} blocks)
+      </div>
+      <div className="debug-block-list">
+        {blocks.map((block, i) => (
+          <div key={i}>
+            <div
+              className={`debug-block${block.isCurrent ? ' debug-block-current' : ''}${block.dirty ? ' debug-block-dirty' : ''}`}
+            >
+              <div className="debug-block-header">
+                <span className="debug-block-type">{block.blockType}</span>
+                <span className="debug-block-line">L{block.lineStart}</span>
+                {block.dirty && <span className="debug-block-badge dirty">dirty</span>}
+                {block.hasServerState && (
+                  <span className="debug-block-badge synced">v{block.version}</span>
+                )}
+              </div>
+              <div className="debug-block-content">
+                {block.content.length > 80
+                  ? block.content.slice(0, 80) + '…'
+                  : block.content || '(empty)'}
+              </div>
+              {block.nodeId && (
+                <div className="debug-block-id">{block.nodeId.slice(0, 8)}…</div>
+              )}
+            </div>
+            {i < blocks.length - 1 && (
+              <div className="debug-connector">
+                <div className="debug-connector-line" />
+                <span className="debug-connector-label">↕</span>
+                <div className="debug-connector-line" />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'react-router';
 import { fetchNodes } from '../api/nodes';
@@ -7,6 +7,8 @@ import type { BlockNode } from '../markdown/blockList';
 import { parseMarkdownBlocks } from '../markdown/parser';
 import { executeSave } from '../markdown/reconcile';
 import { useUser } from '../contexts/UserContext';
+import DebugBlockView from './DebugBlockView';
+import type { DebugBlockSnapshot } from './DebugBlockView';
 
 function lineFromCharOffset(text: string, charOffset: number): number {
   let line = 0;
@@ -43,6 +45,8 @@ export default function NoteEditor() {
   const [text, setText] = useState('');
   const [status, setStatus] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [debugOpen, setDebugOpen] = useState(false);
+  const [debugVersion, setDebugVersion] = useState(0);
   const blockListRef = useRef<BlockList>(new BlockList());
   const currentBlockRef = useRef<BlockNode | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -62,6 +66,10 @@ export default function NoteEditor() {
     currentBlockRef.current = bl.head;
     setStatus(null);
   }, [nodes]);
+
+  const bumpDebugVersion = useCallback(() => {
+    setDebugVersion(v => v + 1);
+  }, []);
 
   const handleTextChange = useCallback((newText: string) => {
     const bl = blockListRef.current;
@@ -92,6 +100,7 @@ export default function NoteEditor() {
       const rebuilt = bl.toText();
       setText(rebuilt);
       setStatus(null);
+      bumpDebugVersion();
       return;
     }
 
@@ -105,6 +114,7 @@ export default function NoteEditor() {
       currentBlockRef.current = bl.getBlockAtLine(cursorLine);
       setText(bl.toText());
       setStatus(null);
+      bumpDebugVersion();
       return;
     }
 
@@ -119,6 +129,7 @@ export default function NoteEditor() {
       setText(rebuilt);
       currentBlockRef.current = currentBlock;
       setStatus(null);
+      bumpDebugVersion();
       return;
     }
 
@@ -127,7 +138,8 @@ export default function NoteEditor() {
     currentBlockRef.current = bl.getBlockAtLine(cursorLine);
     setText(newText);
     setStatus(null);
-  }, []);
+    bumpDebugVersion();
+  }, [bumpDebugVersion]);
 
   const handleCursorMove = useCallback(() => {
     const textarea = textareaRef.current;
@@ -135,7 +147,8 @@ export default function NoteEditor() {
     const cursorLine = lineFromCharOffset(text, textarea.selectionStart);
     const bl = blockListRef.current;
     currentBlockRef.current = bl.getBlockAtLine(cursorLine);
-  }, [text]);
+    bumpDebugVersion();
+  }, [text, bumpDebugVersion]);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
@@ -156,6 +169,31 @@ export default function NoteEditor() {
     }
   }, [notebookId, noteId, userId, queryClient]);
 
+  const debugBlocks = useMemo((): DebugBlockSnapshot[] => {
+    if (!debugOpen) return [];
+    const blocks: DebugBlockSnapshot[] = [];
+    let current = blockListRef.current.head;
+    let index = 0;
+    while (current !== null) {
+      blocks.push({
+        index,
+        blockType: current.blockType,
+        content: current.content,
+        lineStart: current.lineStart,
+        lineCount: current.lineCount,
+        dirty: current.dirty,
+        hasServerState: current.serverState !== null,
+        nodeId: current.serverState?.nodeId ?? null,
+        version: current.serverState?.version ?? null,
+        isCurrent: current === currentBlockRef.current,
+      });
+      current = current.next;
+      index++;
+    }
+    return blocks;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debugOpen, debugVersion]);
+
   if (!notebookId || !noteId) {
     return <div className="editor-placeholder">Select a note to edit</div>;
   }
@@ -171,19 +209,28 @@ export default function NoteEditor() {
 
   return (
     <div className="note-editor">
-      <textarea
-        ref={textareaRef}
-        value={text}
-        onChange={(e) => handleTextChange(e.target.value)}
-        onSelect={handleCursorMove}
-        onKeyUp={handleCursorMove}
-      />
+      <div className={`editor-content${debugOpen ? ' with-debug' : ''}`}>
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={(e) => handleTextChange(e.target.value)}
+          onSelect={handleCursorMove}
+          onKeyUp={handleCursorMove}
+        />
+        {debugOpen && <DebugBlockView blocks={debugBlocks} />}
+      </div>
       <div className="editor-toolbar">
         <button
           onClick={handleSave}
           disabled={!isDirty || saving}
         >
           {saving ? 'Saving...' : 'Save'}
+        </button>
+        <button
+          className="debug-toggle"
+          onClick={() => setDebugOpen(prev => !prev)}
+        >
+          {debugOpen ? 'Hide Debug' : 'Debug'}
         </button>
         {status && <span className={`status ${status.startsWith('Error') || status.startsWith('Conflict') ? 'error' : 'success'}`}>{status}</span>}
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -204,3 +204,152 @@ ul {
 .status.error {
   color: #c00;
 }
+
+/* Editor content area (textarea + optional debug panel) */
+
+.editor-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.editor-content.with-debug {
+  flex-direction: row;
+  gap: 16px;
+}
+
+.editor-content.with-debug textarea {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Debug toggle button (secondary style) */
+
+.debug-toggle {
+  padding: 8px 16px;
+  border: 1px solid #ccc !important;
+  background: #fff !important;
+  color: #666 !important;
+}
+
+.debug-toggle:hover:not(:disabled) {
+  background: #f0f0f0 !important;
+  color: #333 !important;
+}
+
+/* Debug panel */
+
+.debug-panel {
+  width: 320px;
+  min-width: 280px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #f8f8fc;
+  overflow-y: auto;
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+}
+
+.debug-panel-header {
+  padding: 8px 12px;
+  font-weight: 600;
+  font-size: 13px;
+  border-bottom: 1px solid #ddd;
+  background: #f0f0f5;
+  position: sticky;
+  top: 0;
+}
+
+.debug-block-list {
+  padding: 12px;
+}
+
+.debug-block {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 8px 10px;
+  background: #fff;
+}
+
+.debug-block-current {
+  border-color: #6366f1;
+  border-width: 2px;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+
+.debug-block-dirty {
+  border-left: 3px solid #f59e0b;
+}
+
+.debug-block-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.debug-block-type {
+  font-weight: 600;
+  color: #6366f1;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+}
+
+.debug-block-line {
+  color: #666;
+  font-size: 11px;
+}
+
+.debug-block-badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.debug-block-badge.dirty {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.debug-block-badge.synced {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.debug-block-content {
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+  font-size: 11px;
+  color: #444;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 60px;
+  overflow: hidden;
+}
+
+.debug-block-id {
+  font-size: 10px;
+  color: #999;
+  margin-top: 4px;
+}
+
+.debug-connector {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.debug-connector-line {
+  width: 1px;
+  height: 8px;
+  background: #999;
+}
+
+.debug-connector-label {
+  font-size: 10px;
+  color: #999;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary

- Adds a toggleable debug panel that renders side-by-side with the textarea in the note editor
- Each block card shows type, line position, content preview, dirty/synced state, and server node ID
- The block where the cursor is currently positioned is highlighted with an indigo border
- Updates in real time as the user moves the cursor or edits text (splits, merges, content changes)

## How it works

The block list and current block are stored in refs (don't trigger re-renders). A `debugVersion` counter state is bumped after every block mutation or cursor move. A `useMemo` keyed on this counter snapshots the linked list into a plain array for the `DebugBlockView` component. When the panel is closed, the snapshot short-circuits to `[]` and the component is not mounted.

## Test plan

- [x] Click "Debug" button — panel appears to the right of the textarea
- [x] Panel shows correct block types (HEADING, PARAGRAPH, LIST_ITEM, etc.), line numbers, and content
- [x] Current block highlighted with indigo border, follows cursor movement
- [x] Editing text updates the panel in real time (content changes, dirty badge appears)
- [x] Block splits (typing `\n\n`) and merges (deleting separators) reflected immediately
- [x] Click "Hide Debug" — panel disappears, textarea expands back to full width
- [x] All 85 existing Vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)