### PR TITLE
docs: add frontend architecture document and source docstrings

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -156,3 +156,4 @@ the webui.
 - [`Notes Service`](notesservice.md)
 - [`API`](api.md)
 - [`Markdown support`](markdown.md)
+- [`Web frontend`](frontend.md)

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -1,0 +1,154 @@
+# Frontend Architecture
+
+The frontend is a React single-page application that provides a notebook/note editing interface backed by the REST API. It is built with Vite, TypeScript, React Router, and TanStack React Query.
+
+## High-Level Overview
+
+```mermaid
+graph TB
+    Browser["Browser (React SPA)"]
+
+    subgraph Frontend["Frontend (Vite dev server :5173)"]
+        Router["React Router"]
+        RQ["React Query Cache"]
+        API["API Client (apiFetch)"]
+        MD["Markdown Engine<br/>(parser + BlockList + reconcile)"]
+    end
+
+    subgraph Backend["Backend API (:8000)"]
+        REST["/notebook, /note, /node endpoints"]
+        DB[(PostgreSQL)]
+    end
+
+    Browser --> Router
+    Router --> RQ
+    RQ --> API
+    API -- "HTTP (JSON)" --> REST
+    REST --> DB
+
+    MD -- "executeSave()" --> API
+    RQ -- "nodes response" --> MD
+```
+
+The frontend runs as a Node/Vite dev server on port 5173 and communicates with the Python backend API on port 8000 over HTTP/JSON. All server state is managed through React Query; there is no client-side persistence.
+
+## Provider Hierarchy
+
+The application mounts a nested provider stack in `main.tsx`:
+
+```
+StrictMode
+  QueryClientProvider      -- React Query cache (refetchOnWindowFocus: false)
+    BrowserRouter          -- React Router v7
+      UserProvider         -- fetches current user, provides userId via context
+        App                -- route definitions
+```
+
+## Routing
+
+All routes render the same `Layout` component; URL params determine what content is visible:
+
+| Route | Behavior |
+|---|---|
+| `/` | Redirects to `/notebooks` |
+| `/notebooks` | Sidebar shows notebook list only |
+| `/notebooks/:notebookId/notes` | Sidebar shows notebook list + note list |
+| `/notebooks/:notebookId/notes/:noteId` | Sidebar + note editor in main area |
+
+## Component Tree
+
+```mermaid
+graph TD
+    Layout --> NotebookList
+    Layout --> NoteList
+    Layout --> NoteEditor
+    NoteEditor --> DebugBlockView
+
+    NotebookList -- "React Query" --> API_Notebooks["api/notebooks"]
+    NoteList -- "React Query" --> API_Notes["api/notes"]
+    NoteEditor -- "React Query" --> API_Nodes["api/nodes"]
+    NoteEditor --> BlockList["BlockList (ref)"]
+    NoteEditor -- "save" --> Reconcile["reconcile.executeSave()"]
+    Reconcile --> API_Nodes
+```
+
+### Layout
+
+Top-level composition component (`components/Layout.tsx`). Reads `notebookId` and `noteId` from URL params and renders a two-panel layout:
+- **Sidebar** (300px fixed): `NotebookList` always visible; `NoteList` shown when a notebook is selected.
+- **Main area** (flex): `NoteEditor` when a note is selected; placeholder message otherwise.
+
+### NotebookList
+
+Lists the user's notebooks with create/delete support (`components/NotebookList.tsx`). Uses React Query to fetch and mutate notebooks. Clicking a notebook navigates to its notes route. The active notebook is highlighted based on the URL.
+
+### NoteList
+
+Lists notes within the selected notebook (`components/NoteList.tsx`). Same CRUD pattern as NotebookList. Returns `null` when no notebook is selected.
+
+### NoteEditor
+
+The main editing surface (`components/NoteEditor.tsx`). This is the most complex component, connecting the textarea UI to the markdown block engine:
+
+1. **Load**: Fetches `NoteNode[]` from the server, builds a `BlockList`, serializes to text for the textarea.
+2. **Edit**: On each keystroke, identifies the current block by cursor position and applies the appropriate operation (update, split on double-newline, or merge when a separator is deleted).
+3. **Save**: Calls `executeSave()` to reconcile dirty blocks with the server. Handles 409 conflicts.
+
+Holds a `BlockList` instance in a ref that persists across renders.
+
+### DebugBlockView
+
+Optional side panel toggled from the editor toolbar (`components/DebugBlockView.tsx`). Renders a visual representation of the internal `BlockList` state showing block types, dirty/synced status, line positions, and the block under the cursor.
+
+## Markdown Engine
+
+The `src/markdown/` module is the core data layer of the editor. Three files work together to parse text into blocks, maintain them in a linked list, and sync changes to the server.
+
+### Parser (`markdown/parser.ts`)
+
+Converts raw markdown text into an array of `ParsedBlock` objects. Each block has a `blockType`, `content`, and `lineCount`.
+
+- `classifyBlockType(content)` -- inspects the first line to determine the block type (heading, blockquote, list_item, image, code_block, or paragraph).
+- `parseMarkdownBlocks(text)` -- splits text at block boundaries. Code blocks are delimited by triple-backtick fences. Headings and images are always single-line blocks. Other types consume consecutive non-blank lines until a type change or blank line.
+
+### BlockList (`markdown/blockList.ts`)
+
+A doubly-linked list of `BlockNode` objects that represents the in-memory document structure. Each node tracks:
+- Content and block type
+- Line position metadata (`lineStart`, `lineCount`)
+- Server state (`nodeId`, `version`, `nodeType`) -- `null` for unsaved blocks
+- A `dirty` flag set on any local modification
+
+Key operations:
+- `buildFromServerNodes(nodes)` -- constructs the list from API response. Handles both `markdown` nodes (1:1 mapping) and legacy `text` nodes (parsed into multiple blocks for migration).
+- `insertAfter()` / `remove()` / `updateBlock()` -- structural mutations that mark blocks dirty and recompute line starts.
+- `splitBlock()` / `mergeWithNext()` -- used by the editor when the user creates or removes block separators.
+- `toText()` -- serializes the list back to a string (blocks joined by `\n\n`).
+
+The list also maintains a `deletedNodeIds` array to track server nodes that need deletion on the next save.
+
+### Reconcile (`markdown/reconcile.ts`)
+
+The sync engine that persists local changes to the server. `executeSave()` runs four sequential phases:
+
+1. **Delete removed blocks** -- deletes server nodes for blocks that were removed from the list.
+2. **Migrate TEXT nodes** -- deletes legacy TEXT-type server nodes so they can be re-created as MARKDOWN nodes.
+3. **Create new blocks** -- creates server nodes for blocks with no `serverState`, using positional hints (`afterNodeId`, `beforeNodeId`) to maintain ordering.
+4. **Update dirty blocks** -- patches blocks that have server state but were modified locally. Uses optimistic concurrency control via `expected_version`.
+
+## API Layer
+
+All API modules live in `src/api/` and use a shared `apiFetch()` wrapper (`api/client.ts`) that:
+- Reads `VITE_API_BASE_URL` (defaults to `http://localhost:8000`)
+- Sets `Content-Type: application/json` and `X-User-Id` headers as needed
+- Throws `ApiError` (with HTTP status) on non-OK responses
+
+Modules: `users.ts`, `notebooks.ts`, `notes.ts`, `nodes.ts`.
+
+## Data Flow Summary
+
+```
+Load:  Server nodes --> BlockList.buildFromServerNodes() --> BlockList.toText() --> textarea
+Edit:  Keystroke --> handleTextChange() --> BlockList update/split/merge --> textarea
+Save:  executeSave() --> DELETE/CREATE/PATCH API calls --> update serverState, clear dirty
+```

--- a/frontend/src/components/DebugBlockView.tsx
+++ b/frontend/src/components/DebugBlockView.tsx
@@ -1,3 +1,5 @@
+/** Debug panel that visualizes the internal BlockList state alongside the editor. */
+
 import type { MarkdownBlockType } from '../types';
 
 export interface DebugBlockSnapshot {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,3 +1,5 @@
+/** Two-panel layout: sidebar (notebooks + notes) and main area (editor). URL params drive visibility. */
+
 import { useParams } from 'react-router';
 import NotebookList from './NotebookList';
 import NoteList from './NoteList';

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -1,3 +1,9 @@
+/**
+ * Block-level markdown editor. Loads server nodes into a BlockList, maps
+ * keystrokes to block operations (update/split/merge), and reconciles
+ * dirty blocks back to the server on save.
+ */
+
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'react-router';

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -1,3 +1,5 @@
+/** Sidebar list of notes within the selected notebook. Create/delete via React Query mutations. */
+
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';

--- a/frontend/src/components/NotebookList.tsx
+++ b/frontend/src/components/NotebookList.tsx
@@ -1,3 +1,5 @@
+/** Sidebar list of notebooks with create/delete. Navigates to the selected notebook's notes. */
+
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';

--- a/frontend/src/markdown/blockList.ts
+++ b/frontend/src/markdown/blockList.ts
@@ -1,3 +1,9 @@
+/**
+ * Doubly-linked list of markdown blocks that serves as the in-memory document
+ * model for the editor. Each node tracks its server-side state so the
+ * reconciler can diff local edits into API calls on save.
+ */
+
 import type { MarkdownBlockType, NoteNode } from '../types';
 import { classifyBlockType, parseMarkdownBlocks } from './parser';
 

--- a/frontend/src/markdown/parser.ts
+++ b/frontend/src/markdown/parser.ts
@@ -1,3 +1,8 @@
+/**
+ * Markdown block parser: splits raw text into typed blocks at structural
+ * boundaries (blank lines, headings, fences, etc.) for the block-level editor.
+ */
+
 import type { MarkdownBlockType } from '../types';
 
 export interface ParsedBlock {
@@ -6,6 +11,7 @@ export interface ParsedBlock {
   lineCount: number;
 }
 
+/** Determines the block type by inspecting the first line of content. */
 export function classifyBlockType(content: string): MarkdownBlockType {
   const firstLine = content.split('\n')[0].trimStart();
   if (/^#{1,6}\s/.test(firstLine)) return 'heading';
@@ -24,6 +30,7 @@ function startsNewBlock(line: string): boolean {
   return false;
 }
 
+/** Splits markdown text into an ordered array of blocks. Always returns at least one block. */
 export function parseMarkdownBlocks(text: string): ParsedBlock[] {
   if (text === '') {
     return [{ blockType: 'paragraph', content: '', lineCount: 1 }];

--- a/frontend/src/markdown/reconcile.ts
+++ b/frontend/src/markdown/reconcile.ts
@@ -1,3 +1,9 @@
+/**
+ * Sync engine: reconciles the in-memory BlockList with the server by walking
+ * dirty/deleted blocks and issuing DELETE, CREATE, and PATCH calls in order.
+ * Uses optimistic concurrency control (expected_version) on updates.
+ */
+
 import type { BlockList, BlockNode } from './blockList';
 import { createNode, deleteNode, updateNode } from '../api/nodes';
 


### PR DESCRIPTION
## Summary
- Add `docs/architecture/frontend.md` covering the full frontend architecture: high-level Mermaid diagrams, provider hierarchy, routing, component tree, markdown engine internals (parser, BlockList, reconciler), API layer, and data flow
- Add module-level docstrings to all source files in `frontend/src/components/` and `frontend/src/markdown/`
- Link the new doc from `docs/architecture/README.md`

## Test plan
- [x] All 85 frontend tests pass (`npx vitest run`)
- [ ] Verify Mermaid diagrams render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)