### PR TITLE
docs: update dev docs and Makefile to match current codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,13 @@
 # Assistant Development Guide for AI Agents
 
-... docs ...
-
-## Project Structure
-
-```
-assistant/
-├── src/
-│   └── assistant/              # Main package
-│       ├── adapters/           # Data source adapters & plugin system
-│       │   └── plugins/        # Adapter plugins (e.g. fake for testing)
-│       ├── agents/             # RAG agent, vector search, infra
-│       ├── api/                # FastAPI REST API
-│       │   ├── routes/         # Route handlers (users, notebooks, notes)
-│       │   └── schemas/        # Pydantic request/response schemas
-│       ├── cli/                # CLI entry points (server, client, db tools, chat)
-│       ├── data/               # Static data assets
-│       │   └── documents/
-│       ├── evals/              # Evaluation framework
-│       ├── models/             # SQLAlchemy ORM models & DB schema
-│       ├── notes/              # Notes service layer (CRUD, positions, users)
-│       └── tui/                # Terminal UI (Textual chat app)
-├── tests/                      # Test suite (mirrors src/ structure)
-├── docs/                       # Documentation
-│   ├── architecture/           # System architecture
-│   ├── adr/                    # Architecture Decision Records
-│   └── modules/                # Module documentation
-├── .claude/                    # Claude AI configuration
-├── .cursorrules                # Cursor AI configuration
-├── docker-compose.yml          # Dev services (Postgres)
-├── Makefile                    # Build & dev commands
-├── pyproject.toml              # Project configuration
-└── README.md
-```
+Assistant is a smart shared note taking system. It is meant to allow
+people to organize their knowledge in notes and notebooks like Evernote.
+It also includes an AI agent to search, manage and summarize the knowledge
+in a semantic way.
 
 # Working with This Codebase
+
+The repo structure is in [`Project Structure`](docs/project_structure.md)
 
 ## Project Overview
 
@@ -46,7 +19,20 @@ assistant/
 
 ## Architecture
 
-The architecture of the system is described in [`Architecture`](docs/architecture/README.md)
+Before making plans read the architecture documents:
+
+Overall architecture: [`Architecture`](docs/architecture/README.md)
+
+When working on the backend:
+
+- Note service: the backend [`Notes Service`](docs/architecture/notesservice.md)
+- The [`API`](docs/architecture/api.md)
+
+When working on the frontend:
+
+- Support for notes format: [`Markdown support`](docs/architecture/markdown.md)
+- Frontend architecture: [`Web frontend`](docs/architecture/frontend.md)
+
 
 ## Quick Start
 
@@ -56,16 +42,20 @@ The architecture of the system is described in [`Architecture`](docs/architectur
 
 ### Setup Development Environment
 
+Use the makefile to manage the dev environment and the services.
+Only if something does not work read [`devenv.md`](docs/devenv.md) for
+the manual operations
+
 #### Start dev services
 
 We have a docker compose bundle for the db and other dev services
 
 ```bash
-# Start the devservices and detach
-docker compose up -d
+# Starts all the background services
+make services-up
 
-# Stops the devservices
-docker compose down
+# Stops them
+make services-down
 ```
 
 #### Quick Setup (Recommended)
@@ -81,23 +71,6 @@ make dev-setup
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 ```
 
-#### Manual Setup
-
-```bash
-# Install uv if not already installed
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Create virtual environment and install dependencies
-uv venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-
-# Install package in development mode with dev dependencies
-uv pip install -e ".[dev]"
-
-# Install pre-commit hooks
-pre-commit install
-```
-
 ### Running Tests
 
 ```bash
@@ -109,8 +82,6 @@ pytest --cov=assistant --cov-report=term-missing
 ```
 
 ### Code Quality Checks
-
-#### Using Makefile (Recommended)
 
 ```bash
 # Run all checks
@@ -128,26 +99,26 @@ make format
 make pre-commit-run
 ```
 
-#### Manual Commands
-
-```bash
-# Type checking
-mypy src/
-
-# Linting and formatting
-ruff check src/
-black --check src/
-
-# Auto-fix issues
-ruff check --fix src/
-black src/
-```
-
 ## Development Workflow
 
-Every time you apply a change, run tests and typechecking as described below.
+Every time you apply a change, run the relevant checks before committing.
+
+**Backend changes** (anything under `src/` or `tests/`):
+
+```bash
+make check   # runs typecheck + lint + test
+```
+
+**Frontend changes** (anything under `frontend/`):
+
+```bash
+make frontend-check   # runs lint
+make frontend-test    # runs vitest
+```
 
 ### Writing Tests
+
+#### Python tests
 
 - Place tests in `tests/` mirroring the `src/assistant/` structure
 - Use `test_` prefix for test files and functions
@@ -155,6 +126,12 @@ Every time you apply a change, run tests and typechecking as described below.
 - Group related tests with comment separators (e.g. `# --- Create node ---`)
 - Aim for high coverage but focus on meaningful tests
 - Mock external dependencies
+
+#### Frontend tests
+
+- Place tests next to source files as `*.test.tsx` or in `frontend/src/test/`
+- Use Vitest with React Testing Library
+- Run with `make frontend-test` or `cd frontend && npm test`
 
 ### Type Checking
 
@@ -172,6 +149,18 @@ This project uses strict typing:
 - Keep examples in sync with code
 
 ## Common Tasks
+
+### Start the application
+
+The Makefile contains some targets to start and stop both frontend and api
+
+```bash
+# Start both
+make dev
+
+# Stop both
+make dev-stop
+```
 
 ### Chat TUI
 
@@ -192,7 +181,7 @@ Start the API server (requires Postgres to be running, see below):
 python -m assistant.cli.setup_database
 
 # Start the server
-python -m assistant.cli.api_server
+make server
 ```
 
 The server runs on `http://localhost:8000` by default. Options:
@@ -201,6 +190,30 @@ The server runs on `http://localhost:8000` by default. Options:
 - `--reload` (auto-reload on code changes)
 
 OpenAPI docs are available at `http://localhost:8000/docs`.
+
+### Frontend
+
+In order to start, lint and test the frontend alone
+
+```bash
+# Install frontend dependencies
+make frontend-install
+
+# Start frontend dev server
+make frontend-dev
+
+# Build frontend for production
+make frontend-build
+
+# Lint frontend code
+make frontend-lint
+
+# Run frontend tests (vitest)
+make frontend-test
+
+# Run all frontend checks (lint + test)
+make frontend-check
+```
 
 ### API Client CLI
 
@@ -233,12 +246,17 @@ When a task needs the Postgres database (e.g. running app code or tests that hit
 
 ### Adding a Dependency
 
-```bash
-# Add to pyproject.toml under [project.dependencies]
-# or for dev dependencies under [project.optional-dependencies.dev]
+**Python**: add the package to `pyproject.toml` under `[project.dependencies]`
+(or `[project.optional-dependencies.dev]` for dev deps), then sync:
 
-# Then sync the environment
-uv pip install -e ".[dev]"
+```bash
+make sync   # runs uv sync --all-extras
+```
+
+**Frontend**: use npm from the `frontend/` directory:
+
+```bash
+cd frontend && npm install <package>
 ```
 
 ### Running Individual Tests
@@ -251,8 +269,7 @@ pytest tests/test_specific.py::test_function_name
 ### Updating Documentation
 
 1. Code-level: Update docstrings in the code
-2. Module-level: Update docs in `docs/modules/`
-3. Architecture-level: Create or update ADRs in `docs/adr/`
+2. Architecture-level: Create or update ADRs in `docs/architecture/`
 4. Project-level: Update README.md
 
 ## Conventions

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install-uv setup sync install test typecheck lint format check clean pre-commit-install pre-commit-run services-up services-down server frontend-install frontend-dev frontend-build frontend-lint frontend-check dev dev-stop
+.PHONY: help install-uv setup sync install test typecheck lint format check clean pre-commit-install pre-commit-run services-up services-down server frontend-install frontend-dev frontend-build frontend-lint frontend-test frontend-check dev dev-stop
 
 # Default target
 help:
@@ -21,6 +21,7 @@ help:
 	@echo "  make frontend-dev        - Start frontend dev server"
 	@echo "  make frontend-build      - Build frontend for production"
 	@echo "  make frontend-lint       - Lint frontend code"
+	@echo "  make frontend-test       - Run frontend tests (vitest)"
 	@echo "  make frontend-check      - Run all frontend checks"
 	@echo "  make dev                 - Start both backend and frontend dev servers"
 	@echo "  make dev-stop            - Stop backend and frontend dev servers"
@@ -144,8 +145,13 @@ frontend-lint:
 	@echo "Linting frontend..."
 	@cd frontend && npm run lint
 
+# Run frontend tests
+frontend-test:
+	@echo "Running frontend tests..."
+	@cd frontend && npm test
+
 # Run all frontend checks
-frontend-check: frontend-lint
+frontend-check: frontend-lint frontend-test
 	@echo "✅ Frontend checks passed"
 
 # Start both backend and frontend dev servers
@@ -161,7 +167,7 @@ dev-stop:
 	@echo "Dev servers stopped"
 
 # Quick development setup (run once)
-dev-setup: setup install pre-commit-install
+dev-setup: setup install pre-commit-install frontend-install
 	@echo ""
 	@echo "✅ Development environment ready!"
 	@echo ""

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -1,0 +1,44 @@
+# Project Structure
+
+```
+assistant/
+├── src/                        # The backend code
+│   └── assistant/              # Main Python package
+│       ├── adapters/           # Data source adapters & plugin system
+│       │   └── plugins/        # Adapter plugins (e.g. fake for testing)
+│       ├── agents/             # RAG agent, vector search, infra
+│       ├── api/                # FastAPI REST API
+│       │   ├── routes/         # Route handlers (users, notebooks, notes)
+│       │   └── schemas/        # Pydantic request/response schemas
+│       ├── cli/                # CLI entry points (server, client, db tools, chat)
+│       ├── data/               # Static data assets
+│       │   └── documents/
+│       ├── evals/              # Evaluation framework
+│       ├── models/             # SQLAlchemy ORM models & DB schema
+│       ├── notes/              # Notes service layer (CRUD, positions, users)
+│       └── tui/                # Terminal UI (Textual chat app)
+├── frontend/                   # React/TypeScript web UI (Vite)
+│   └── src/
+│       ├── api/                # API client layer
+│       ├── components/         # React components (Layout, NoteEditor, etc.)
+│       ├── contexts/           # React context providers
+│       ├── markdown/           # Markdown parsing & rendering
+│       ├── test/               # Frontend test utilities
+│       └── types/              # TypeScript type definitions
+├── tests/                      # Python test suite (mirrors src/ structure)
+├── data/                       # Runtime data assets
+│   ├── documents/
+│   └── evals/
+├── scripts/                    # Utility scripts (e.g. verify_setup.sh)
+├── docs/                       # Documentation
+│   ├── architecture/           # System architecture
+│   ├── adr/                    # Architecture Decision Records
+│   └── modules/                # Module documentation
+│       └── registry/
+├── .claude/                    # Claude AI configuration
+├── config.yaml                 # Application configuration
+├── docker-compose.yml          # Dev services (Postgres)
+├── Makefile                    # Build & dev commands
+├── pyproject.toml              # Python project configuration
+└── README.md
+```


### PR DESCRIPTION
## Summary
- Fix broken doc links in AGENTS.md (now point to `docs/architecture/`)
- Add frontend development workflow guidance (testing, linting, dependency management)
- Add `make frontend-test` target (runs vitest) and include tests in `frontend-check`
- Include `frontend-install` in `dev-setup` so quick setup covers the full stack
- Update `project_structure.md` to reflect the frontend/ tree and other new top-level entries
- Fix stale "Adding a Dependency" section to use `make sync` instead of `uv pip install`

## Test plan
- [x] `make frontend-test` runs and all 85 tests pass
- [ ] Verify doc links resolve correctly on GitHub
- [ ] Run `make dev-setup` on a clean checkout to confirm frontend-install is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)