### PR TITLE
feat: JWT-based authentication with user-scoped data

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -157,3 +157,4 @@ the webui.
 - [`API`](api.md)
 - [`Markdown support`](markdown.md)
 - [`Web frontend`](frontend.md)
+- [`Authentication`](authentication.md)

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -30,7 +30,7 @@ integrations for now.
 
 ### Access Token (JWT)
 
-- **Lifetime:** 15 minutes
+- **Lifetime:** 5 minutes
 - **Format:** Signed JWT
 - **Claims:** `sub` (user UUID), `exp`, `iat`
 - **Validation:** Stateless — signature and expiry check only. No DB

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -1,0 +1,230 @@
+# Authentication
+
+## Overview
+
+The system supports two authentication modes and two identity providers.
+Authentication is based on JWT access tokens and refresh tokens. The
+access token is stateless — the server does not check it against the DB
+on every request. Revocation relies on token expiration.
+
+## Authentication Modes
+
+A request must use exactly one of these modes. If both are present, the
+server rejects the request with 401.
+
+### Cookie Mode (Web UI)
+
+For browser-based sessions. The access token and refresh token are
+delivered as `HttpOnly`, `Secure`, `SameSite=Lax` cookies. The frontend
+communicates with the API through a Vite dev-server proxy in development
+so that cookies are same-origin. In production the API server serves the
+frontend, so cookies remain same-origin.
+
+### Bearer Token Mode (Mobile / Native Clients)
+
+For mobile apps and native clients. Tokens are returned in the response
+body and sent via `Authorization: Bearer <token>` header. No third-party
+integrations for now.
+
+## Token Design
+
+### Access Token (JWT)
+
+- **Lifetime:** 15 minutes
+- **Format:** Signed JWT
+- **Claims:** `sub` (user UUID), `exp`, `iat`
+- **Validation:** Stateless — signature and expiry check only. No DB
+  round-trip per request.
+
+### Refresh Token
+
+- **Lifetime:** 7 days
+- **Storage:** Stored in the database with a `family_id` column to
+  support rotation and replay detection.
+- **Rotation:** Every use of a refresh token issues a new refresh token
+  and invalidates the old one. If a previously used refresh token is
+  replayed, the entire token family is invalidated (all refresh tokens
+  with the same `family_id` are deleted).
+
+### Revocation
+
+Revocation is handled by deleting refresh tokens from the database.
+Because access tokens are stateless and not checked against a blocklist,
+a revoked user retains access until their current access token expires
+(up to 15 minutes).
+
+- **Logout:** Deletes the refresh token family server-side. Client
+  clears local tokens/cookies.
+- **Compromise:** Delete all refresh tokens for the user. Exposure
+  window is bounded by the access token lifetime.
+
+## Identity Providers
+
+### Username and Password
+
+Identities are stored in the database. Passwords are hashed with
+**Argon2**. Authentication is a lookup by `(email, provider='password')`
+joining the user and credentials tables.
+
+### Google OAuth2
+
+> **Not yet implemented.** Design details to be finalized when this is
+> built.
+
+Authentication via Google OAuth2. Lookup is by
+`(provider='google', provider_subject=<google sub claim>)`.
+
+## Provider Linking
+
+A user's email is unique across the system. When a user authenticates
+with a new provider whose email matches an existing account, the system
+requires verification through the existing provider before linking.
+
+**Example:** A user has a password account. They click "Log in with
+Google" and the Google account has the same email. The system prompts
+them to enter their existing password. Only after successful
+verification is the Google credential linked to the account.
+
+This prevents account takeover via unverified provider linking.
+
+Once linked, the previous credential is replaced — for example, linking
+Google to a password account disables password login for that user.
+
+## Data Model
+
+```mermaid
+erDiagram
+    User ||--o{ Credential : "authenticates via"
+    User ||--o{ RefreshToken : "has"
+
+    User {
+        uid UUID PK
+        email STRING UK
+        firstname STRING
+        lastname STRING
+    }
+
+    Credential {
+        id UUID PK
+        user_id UUID FK
+        provider ENUM "password, google"
+        credential_hash STRING "nullable, argon2 for password"
+        provider_subject STRING "nullable, sub claim for google"
+    }
+
+    RefreshToken {
+        id UUID PK
+        user_id UUID FK
+        family_id UUID
+        token_hash STRING
+        expires_at DATETIME
+        created_at DATETIME
+    }
+```
+
+**Unique constraints:**
+- `Credential(user_id, provider)` — one credential per provider per user
+- `Credential(provider, provider_subject)` — prevents two users from
+  linking the same external account
+- `RefreshToken(token_hash)` — for lookup on refresh
+
+The `User` table remains a profile table. Authentication concerns are
+isolated in `Credential` and `RefreshToken`.
+
+## API Endpoints
+
+### Registration and Login
+
+`POST /auth/register`
+
+Creates a user and a password credential.
+
+Request body:
+```json
+{
+    "email": "user@example.com",
+    "password": "secret",
+    "firstname": "Jane",
+    "lastname": "Doe"
+}
+```
+
+Response (201): User profile (no tokens — client must log in).
+
+`POST /auth/login`
+
+Authenticates with email and password. Returns tokens via cookies or
+response body depending on the client mode.
+
+Request body:
+```json
+{
+    "email": "user@example.com",
+    "password": "secret"
+}
+```
+
+Response (200): Access token and refresh token. Delivery mechanism
+depends on the auth mode (cookie or bearer).
+
+### Token Management
+
+`POST /auth/refresh`
+
+Exchanges a refresh token for a new access token and a rotated refresh
+token. The old refresh token is invalidated. Replay of a consumed
+refresh token invalidates the entire family.
+
+`POST /auth/logout`
+
+Invalidates the refresh token family. Client clears local state.
+
+### Google OAuth2 (future)
+
+`GET /auth/google` — Initiates the OAuth2 flow.
+
+`POST /auth/google/callback` — Completes the OAuth2 flow.
+
+### Provider Linking
+
+`POST /auth/link`
+
+Links a new authentication provider to an existing account. Requires
+proof of ownership via the current provider (e.g., password
+verification) before linking.
+
+## Middleware
+
+A single FastAPI dependency resolves the current user from the request:
+
+1. Check for `Authorization: Bearer` header and for auth cookie.
+2. If both are present, reject with 401.
+3. If neither is present, reject with 401.
+4. Validate the JWT (signature, expiry).
+5. Extract `sub` claim as the user ID.
+
+This dependency replaces the current `X-User-Id` header mechanism. The
+cutover is a hard switch — no backward compatibility period.
+
+## Websocket Authentication
+
+The websocket server authenticates on the HTTP upgrade handshake only.
+The cookie or bearer token is validated during the upgrade. Once the
+connection is established, no further token checks occur per message.
+
+Token expiry during an active websocket connection does not terminate
+the connection. The client must re-authenticate on reconnect.
+
+## Frontend Integration
+
+The frontend uses cookie mode. The Vite dev server proxies API requests
+so that cookies are same-origin in development. In production, the API
+server serves the frontend static files.
+
+The existing `X-User-Id` header in `apiFetch()` is removed. The browser
+sends cookies automatically — no frontend token management needed for
+the web UI.
+
+The `UserProvider` context is updated to fetch the current user from an
+authenticated endpoint (e.g., `GET /auth/me`) instead of using a
+hardcoded user ID.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,28 @@
 import { Routes, Route, Navigate } from 'react-router';
 import Layout from './components/Layout';
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
+import { AuthProvider } from './contexts/AuthContext';
+
+function ProtectedRoutes() {
+  return (
+    <AuthProvider>
+      <Routes>
+        <Route path="/" element={<Navigate to="/notebooks" replace />} />
+        <Route path="/notebooks" element={<Layout />} />
+        <Route path="/notebooks/:notebookId/notes" element={<Layout />} />
+        <Route path="/notebooks/:notebookId/notes/:noteId" element={<Layout />} />
+      </Routes>
+    </AuthProvider>
+  );
+}
 
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<Navigate to="/notebooks" replace />} />
-      <Route path="/notebooks" element={<Layout />} />
-      <Route path="/notebooks/:notebookId/notes" element={<Layout />} />
-      <Route path="/notebooks/:notebookId/notes/:noteId" element={<Layout />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route path="/*" element={<ProtectedRoutes />} />
     </Routes>
   );
 }

--- a/frontend/src/api/auth.test.ts
+++ b/frontend/src/api/auth.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { register, login, logout, getMe } from './auth';
+import { ApiError } from './client';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function okResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: true,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function errResponse(status: number, detail: string) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    statusText: 'Error',
+    json: () => Promise.resolve({ detail }),
+  } as Response);
+}
+
+const USER = { uid: 'u1', email: 'a@b.com', firstname: 'A', lastname: 'B' };
+
+describe('auth API', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('register', () => {
+    it('POSTs to /auth/register and returns the user', async () => {
+      mockFetch.mockReturnValueOnce(okResponse(USER, 201));
+
+      const result = await register({ email: 'a@b.com', password: 'pw', firstname: 'A', lastname: 'B' });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/auth/register');
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toMatchObject({ email: 'a@b.com' });
+      expect(result).toEqual(USER);
+    });
+
+    it('throws ApiError on 409', async () => {
+      mockFetch.mockReturnValueOnce(errResponse(409, 'Email already registered'));
+
+      await expect(register({ email: 'a@b.com', password: 'pw', firstname: 'A', lastname: 'B' }))
+        .rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('login', () => {
+    it('POSTs to /auth/login and returns the user', async () => {
+      mockFetch.mockReturnValueOnce(okResponse(USER));
+
+      const result = await login({ email: 'a@b.com', password: 'pw' });
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/auth/login');
+      expect(opts.method).toBe('POST');
+      expect(result).toEqual(USER);
+    });
+
+    it('throws ApiError with status 401 on bad credentials', async () => {
+      mockFetch.mockReturnValueOnce(errResponse(401, 'Invalid credentials'));
+
+      const err = await login({ email: 'a@b.com', password: 'wrong' }).catch(e => e);
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(401);
+    });
+  });
+
+  describe('logout', () => {
+    it('POSTs to /auth/logout', async () => {
+      mockFetch.mockReturnValueOnce(okResponse(null, 204));
+
+      await logout();
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/auth/logout');
+      expect(opts.method).toBe('POST');
+    });
+  });
+
+  describe('getMe', () => {
+    it('GETs /auth/me and returns the user', async () => {
+      mockFetch.mockReturnValueOnce(okResponse(USER));
+
+      const result = await getMe();
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/auth/me');
+      expect(opts?.method).toBeUndefined();
+      expect(result).toEqual(USER);
+    });
+
+    it('throws ApiError with status 401 when unauthenticated', async () => {
+      mockFetch.mockReturnValueOnce(errResponse(401, 'Authentication required'));
+
+      const err = await getMe().catch(e => e);
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(401);
+    });
+  });
+
+  it('sets credentials: include on every request', async () => {
+    mockFetch.mockReturnValue(okResponse(USER));
+    await getMe();
+    expect(mockFetch.mock.calls[0][1].credentials).toBe('include');
+  });
+});

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,36 @@
+import { apiFetch } from './client';
+import type { User } from '../types';
+
+export interface RegisterPayload {
+  email: string;
+  password: string;
+  firstname: string;
+  lastname: string;
+}
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export function register(payload: RegisterPayload): Promise<User> {
+  return apiFetch<User>('/auth/register', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export function login(payload: LoginPayload): Promise<User> {
+  return apiFetch<User>('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export function logout(): Promise<void> {
+  return apiFetch<void>('/auth/logout', { method: 'POST' });
+}
+
+export function getMe(): Promise<User> {
+  return apiFetch<User>('/auth/me');
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,21 +8,18 @@ export class ApiError extends Error {
 
 export async function apiFetch<T>(
   path: string,
-  options: RequestInit & { userId?: string } = {},
+  options: RequestInit = {},
 ): Promise<T> {
-  const { userId, ...fetchOptions } = options;
   const headers: Record<string, string> = {};
 
-  if (fetchOptions.body) {
+  if (options.body) {
     headers['Content-Type'] = 'application/json';
-  }
-  if (userId) {
-    headers['X-User-Id'] = userId;
   }
 
   const response = await fetch(`${BASE_URL}${path}`, {
-    ...fetchOptions,
-    headers: { ...headers, ...(fetchOptions.headers as Record<string, string>) },
+    ...options,
+    credentials: 'include',
+    headers: { ...headers, ...(options.headers as Record<string, string>) },
   });
 
   if (!response.ok) {

--- a/frontend/src/api/nodes.ts
+++ b/frontend/src/api/nodes.ts
@@ -13,7 +13,6 @@ export function createNode(
     blockType?: string;
     afterNodeId?: string;
     beforeNodeId?: string;
-    userId?: string;
   } = {},
 ): Promise<NoteNode> {
   const body: Record<string, string> = { payload };
@@ -23,7 +22,6 @@ export function createNode(
   return apiFetch<NoteNode>(`/notebook/${notebookId}/note/${noteId}/node`, {
     method: 'POST',
     body: JSON.stringify(body),
-    userId: opts.userId,
   });
 }
 

--- a/frontend/src/api/notebooks.ts
+++ b/frontend/src/api/notebooks.ts
@@ -1,15 +1,14 @@
 import { apiFetch } from './client';
 import type { Notebook } from '../types';
 
-export function fetchNotebooks(userId: string): Promise<Notebook[]> {
-  return apiFetch<Notebook[]>('/notebook', { userId });
+export function fetchNotebooks(): Promise<Notebook[]> {
+  return apiFetch<Notebook[]>('/notebook');
 }
 
-export function createNotebook(userId: string, name: string): Promise<Notebook> {
+export function createNotebook(name: string): Promise<Notebook> {
   return apiFetch<Notebook>('/notebook', {
     method: 'POST',
     body: JSON.stringify({ name }),
-    userId,
   });
 }
 

--- a/frontend/src/api/notes.ts
+++ b/frontend/src/api/notes.ts
@@ -5,11 +5,10 @@ export function fetchNotes(notebookId: string): Promise<Note[]> {
   return apiFetch<Note[]>(`/notebook/${notebookId}/note`);
 }
 
-export function createNote(userId: string, notebookId: string, title: string): Promise<Note> {
+export function createNote(notebookId: string, title: string): Promise<Note> {
   return apiFetch<Note>(`/notebook/${notebookId}/note`, {
     method: 'POST',
     body: JSON.stringify({ title }),
-    userId,
   });
 }
 

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -4,6 +4,13 @@ import Layout from './Layout';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { Route, Routes } from 'react-router';
 
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { uid: 'u1', email: 'a@b.com', firstname: 'Test', lastname: 'User' },
+    logout: vi.fn(),
+  }),
+}));
+
 vi.mock('./NotebookList', () => ({
   default: () => <div data-testid="notebook-list">NotebookList</div>,
 }));

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,22 +4,33 @@ import { useParams } from 'react-router';
 import NotebookList from './NotebookList';
 import NoteList from './NoteList';
 import NoteEditor from './NoteEditor';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function Layout() {
   const { notebookId, noteId } = useParams();
+  const { user, logout } = useAuth();
 
   return (
-    <div className="layout">
-      <div className="sidebar">
-        <NotebookList />
-        {notebookId && <NoteList />}
-      </div>
-      <div className="main">
-        {noteId ? <NoteEditor /> : (
-          <div className="editor-placeholder">
-            {notebookId ? 'Select a note to edit' : 'Select a notebook to get started'}
-          </div>
-        )}
+    <div className="app-shell">
+      <header className="app-header">
+        <span className="app-title">Assistant</span>
+        <div className="header-user">
+          <span className="user-name">{user.firstname} {user.lastname}</span>
+          <button className="btn-logout" onClick={logout}>Logout</button>
+        </div>
+      </header>
+      <div className="layout">
+        <div className="sidebar">
+          <NotebookList />
+          {notebookId && <NoteList />}
+        </div>
+        <div className="main">
+          {noteId ? <NoteEditor /> : (
+            <div className="editor-placeholder">
+              {notebookId ? 'Select a note to edit' : 'Select a notebook to get started'}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -12,7 +12,6 @@ import { BlockList } from '../markdown/blockList';
 import type { BlockNode } from '../markdown/blockList';
 import { parseMarkdownBlocks } from '../markdown/parser';
 import { executeSave } from '../markdown/reconcile';
-import { useUser } from '../contexts/UserContext';
 import DebugBlockView from './DebugBlockView';
 import type { DebugBlockSnapshot } from './DebugBlockView';
 
@@ -47,7 +46,6 @@ function charLengthAfterBlock(block: BlockNode): number {
 export default function NoteEditor() {
   const { notebookId, noteId } = useParams();
   const queryClient = useQueryClient();
-  const { userId } = useUser();
   const [text, setText] = useState('');
   const [status, setStatus] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -161,7 +159,7 @@ export default function NoteEditor() {
     setStatus(null);
 
     try {
-      await executeSave(notebookId!, noteId!, blockListRef.current, userId);
+      await executeSave(notebookId!, noteId!, blockListRef.current);
       setStatus('Saved');
       queryClient.invalidateQueries({ queryKey: ['nodes', notebookId, noteId] });
     } catch (err) {
@@ -173,7 +171,7 @@ export default function NoteEditor() {
     } finally {
       setSaving(false);
     }
-  }, [notebookId, noteId, userId, queryClient]);
+  }, [notebookId, noteId, queryClient]);
 
   const debugBlocks = useMemo((): DebugBlockSnapshot[] => {
     if (!debugOpen) return [];

--- a/frontend/src/components/NoteList.test.tsx
+++ b/frontend/src/components/NoteList.test.tsx
@@ -11,10 +11,6 @@ vi.mock('../api/notes', () => ({
   deleteNote: vi.fn(),
 }));
 
-vi.mock('../contexts/UserContext', () => ({
-  useUser: () => ({ userId: 'test-user' }),
-}));
-
 import { fetchNotes, createNote, deleteNote } from '../api/notes';
 
 const mockFetchNotes = vi.mocked(fetchNotes);
@@ -91,7 +87,7 @@ describe('NoteList', () => {
     await user.click(screen.getByText('Create'));
 
     await waitFor(() => {
-      expect(mockCreateNote).toHaveBeenCalledWith('test-user', 'nb-1', 'My Note');
+      expect(mockCreateNote).toHaveBeenCalledWith('nb-1', 'My Note');
     });
   });
 

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -4,14 +4,11 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';
 import { fetchNotes, createNote, deleteNote } from '../api/notes';
-import { useUser } from '../contexts/UserContext';
 
 export default function NoteList() {
-  const { notebookId } = useParams();
-  const { userId } = useUser();
+  const { notebookId, noteId } = useParams();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { noteId } = useParams();
   const [newTitle, setNewTitle] = useState('');
 
   const { data: notes = [], isLoading } = useQuery({
@@ -21,7 +18,7 @@ export default function NoteList() {
   });
 
   const createMutation = useMutation({
-    mutationFn: (title: string) => createNote(userId, notebookId!, title),
+    mutationFn: (title: string) => createNote(notebookId!, title),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['notes', notebookId] });
       setNewTitle('');

--- a/frontend/src/components/NotebookList.test.tsx
+++ b/frontend/src/components/NotebookList.test.tsx
@@ -10,10 +10,6 @@ vi.mock('../api/notebooks', () => ({
   deleteNotebook: vi.fn(),
 }));
 
-vi.mock('../contexts/UserContext', () => ({
-  useUser: () => ({ userId: 'test-user' }),
-}));
-
 import { fetchNotebooks, createNotebook, deleteNotebook } from '../api/notebooks';
 
 const mockFetch = vi.mocked(fetchNotebooks);
@@ -68,7 +64,7 @@ describe('NotebookList', () => {
     await user.click(screen.getByText('Create'));
 
     await waitFor(() => {
-      expect(mockCreate).toHaveBeenCalledWith('test-user', 'New NB');
+      expect(mockCreate).toHaveBeenCalledWith('New NB');
     });
   });
 

--- a/frontend/src/components/NotebookList.tsx
+++ b/frontend/src/components/NotebookList.tsx
@@ -4,24 +4,22 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';
 import { fetchNotebooks, createNotebook, deleteNotebook } from '../api/notebooks';
-import { useUser } from '../contexts/UserContext';
 
 export default function NotebookList() {
-  const { userId } = useUser();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { notebookId } = useParams();
   const [newName, setNewName] = useState('');
 
   const { data: notebooks = [], isLoading } = useQuery({
-    queryKey: ['notebooks', userId],
-    queryFn: () => fetchNotebooks(userId),
+    queryKey: ['notebooks'],
+    queryFn: fetchNotebooks,
   });
 
   const createMutation = useMutation({
-    mutationFn: (name: string) => createNotebook(userId, name),
+    mutationFn: (name: string) => createNotebook(name),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notebooks', userId] });
+      queryClient.invalidateQueries({ queryKey: ['notebooks'] });
       setNewName('');
     },
   });
@@ -29,7 +27,7 @@ export default function NotebookList() {
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteNotebook(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notebooks', userId] });
+      queryClient.invalidateQueries({ queryKey: ['notebooks'] });
     },
   });
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getMe, logout as apiLogout } from '../api/auth';
+import type { User } from '../types';
+
+interface AuthContextValue {
+  user: User;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const queryClient = useQueryClient();
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const { data: user, isLoading, error } = useQuery({
+    queryKey: ['auth', 'me'],
+    queryFn: getMe,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (isLoading) return <div className="loading">Loading...</div>;
+
+  if (error || !user) {
+    window.location.href = '/login';
+    return null;
+  }
+
+  const logout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await apiLogout();
+    } finally {
+      queryClient.clear();
+      window.location.href = '/login';
+    }
+  };
+
+  if (isLoggingOut) return <div className="loading">Logging out...</div>;
+
+  return (
+    <AuthContext.Provider value={{ user, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,9 +29,59 @@ body {
   overflow-x: auto;
 }
 
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  height: 48px;
+  background: #1a1a1a;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.app-title {
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.02em;
+}
+
+.header-user {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.user-name {
+  font-size: 13px;
+  color: #ccc;
+}
+
+.btn-logout {
+  background: transparent;
+  border: 1px solid #555;
+  color: #ddd;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.btn-logout:hover {
+  background: #333;
+  border-color: #888;
+}
+
 .layout {
   display: flex;
-  height: 100vh;
+  flex: 1;
+  overflow: hidden;
 }
 
 .sidebar {
@@ -40,12 +90,14 @@ body {
   overflow-y: auto;
   padding: 16px;
   background: #fff;
+  height: 100%;
 }
 
 .main {
   flex: 1;
   padding: 24px;
   overflow-y: auto;
+  height: 100%;
 }
 
 h2, h3 {
@@ -352,4 +404,82 @@ ul {
   font-size: 10px;
   color: #999;
   line-height: 1;
+}
+
+/* Auth pages */
+.auth-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+}
+
+.auth-card {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-card h1 {
+  margin: 0 0 1.5rem;
+  font-size: 1.5rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.form-group input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.btn-primary {
+  width: 100%;
+  padding: 0.625rem;
+  background: #1a1a1a;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.auth-error {
+  color: #c00;
+  font-size: 0.875rem;
+  margin: 0.5rem 0;
+}
+
+.auth-footer {
+  text-align: center;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #555;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,6 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { UserProvider } from './contexts/UserContext';
 import App from './App';
 import './index.css';
 
@@ -18,9 +17,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <UserProvider>
-          <App />
-        </UserProvider>
+        <App />
       </BrowserRouter>
     </QueryClientProvider>
   </StrictMode>,

--- a/frontend/src/markdown/reconcile.test.ts
+++ b/frontend/src/markdown/reconcile.test.ts
@@ -41,14 +41,13 @@ describe('executeSave', () => {
     const bl = new BlockList();
     bl.buildFromText('new content');
 
-    await executeSave('nb-1', 'note-1', bl, 'user-1');
+    await executeSave('nb-1', 'note-1', bl);
 
     expect(mockCreateNode).toHaveBeenCalledOnce();
     expect(mockCreateNode).toHaveBeenCalledWith('nb-1', 'note-1', 'new content', {
       blockType: 'paragraph',
       afterNodeId: undefined,
       beforeNodeId: undefined,
-      userId: 'user-1',
     });
   });
 
@@ -59,7 +58,7 @@ describe('executeSave', () => {
     ]);
     bl.updateBlock(bl.head!, 'updated content');
 
-    await executeSave('nb-1', 'note-1', bl, 'user-1');
+    await executeSave('nb-1', 'note-1', bl);
 
     expect(mockUpdateNode).toHaveBeenCalledOnce();
     expect(mockUpdateNode).toHaveBeenCalledWith(
@@ -75,7 +74,7 @@ describe('executeSave', () => {
     ]);
     bl.remove(bl.tail!);
 
-    await executeSave('nb-1', 'note-1', bl, 'user-1');
+    await executeSave('nb-1', 'note-1', bl);
 
     expect(mockDeleteNode).toHaveBeenCalledWith('nb-1', 'note-1', 'n2');
     expect(bl.deletedNodeIds).toEqual([]);
@@ -88,7 +87,7 @@ describe('executeSave', () => {
     ]);
     bl.updateBlock(bl.head!, 'updated');
 
-    await executeSave('nb-1', 'note-1', bl, 'user-1');
+    await executeSave('nb-1', 'note-1', bl);
 
     expect(mockDeleteNode).toHaveBeenCalledWith('nb-1', 'note-1', 'text-1');
     expect(mockCreateNode).toHaveBeenCalled();
@@ -100,7 +99,7 @@ describe('executeSave', () => {
       makeServerNode({ id: 'n1', payload: 'unchanged' }),
     ]);
 
-    await executeSave('nb-1', 'note-1', bl, 'user-1');
+    await executeSave('nb-1', 'note-1', bl);
 
     expect(mockCreateNode).not.toHaveBeenCalled();
     expect(mockUpdateNode).not.toHaveBeenCalled();
@@ -114,7 +113,7 @@ describe('executeSave', () => {
     const bl = new BlockList();
     bl.buildFromText('first\n\nsecond');
 
-    await executeSave('nb-1', 'note-1', bl, 'user-1');
+    await executeSave('nb-1', 'note-1', bl);
 
     expect(mockCreateNode).toHaveBeenCalledTimes(2);
     const firstCallOpts = mockCreateNode.mock.calls[0][3];
@@ -130,7 +129,7 @@ describe('executeSave', () => {
     const bl = new BlockList();
     bl.buildFromText('new');
 
-    await executeSave('nb-1', 'note-1', bl, 'user-1');
+    await executeSave('nb-1', 'note-1', bl);
 
     const block = bl.head!;
     expect(block.serverState).toEqual({ nodeId: 'new-id', version: 5, nodeType: 'markdown' });
@@ -144,7 +143,7 @@ describe('executeSave', () => {
     bl.buildFromServerNodes([makeServerNode({ id: 'n1', version: 3 })]);
     bl.updateBlock(bl.head!, 'changed');
 
-    await executeSave('nb-1', 'note-1', bl, 'user-1');
+    await executeSave('nb-1', 'note-1', bl);
 
     expect(bl.head!.serverState!.version).toBe(10);
     expect(bl.head!.dirty).toBe(false);

--- a/frontend/src/markdown/reconcile.ts
+++ b/frontend/src/markdown/reconcile.ts
@@ -11,7 +11,6 @@ export async function executeSave(
   notebookId: string,
   noteId: string,
   blockList: BlockList,
-  userId: string,
 ): Promise<void> {
   // 1. Delete removed blocks
   for (const nodeId of blockList.deletedNodeIds) {
@@ -37,7 +36,6 @@ export async function executeSave(
         blockType: block.blockType,
         afterNodeId: afterNodeId ?? undefined,
         beforeNodeId: beforeNodeId ?? undefined,
-        userId,
       });
       block.serverState = { nodeId: created.id, version: created.version, nodeType: 'markdown' };
       block.dirty = false;

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginPage from './LoginPage';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { ApiError } from '../api/client';
+
+vi.mock('../api/auth', () => ({
+  login: vi.fn(),
+}));
+
+import { login } from '../api/auth';
+const mockLogin = vi.mocked(login);
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-router')>();
+  return { ...mod, useNavigate: () => mockNavigate };
+});
+
+function renderLogin() {
+  return renderWithProviders(<LoginPage />);
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders email, password fields and a sign in button', () => {
+    renderLogin();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it('calls login with entered credentials on submit', async () => {
+    const user = userEvent.setup();
+    mockLogin.mockResolvedValueOnce({ uid: 'u1', email: 'a@b.com', firstname: 'A', lastname: 'B' });
+
+    renderLogin();
+    await user.type(screen.getByLabelText('Email'), 'a@b.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith({ email: 'a@b.com', password: 'secret' });
+    });
+  });
+
+  it('navigates to /notebooks on successful login', async () => {
+    const user = userEvent.setup();
+    mockLogin.mockResolvedValueOnce({ uid: 'u1', email: 'a@b.com', firstname: 'A', lastname: 'B' });
+
+    renderLogin();
+    await user.type(screen.getByLabelText('Email'), 'a@b.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/notebooks'));
+  });
+
+  it('shows invalid credentials error on 401', async () => {
+    const user = userEvent.setup();
+    mockLogin.mockRejectedValueOnce(new ApiError(401, 'Invalid credentials'));
+
+    renderLogin();
+    await user.type(screen.getByLabelText('Email'), 'a@b.com');
+    await user.type(screen.getByLabelText('Password'), 'wrong');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid email or password.')).toBeInTheDocument();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows generic error on unexpected failure', async () => {
+    const user = userEvent.setup();
+    mockLogin.mockRejectedValueOnce(new Error('network error'));
+
+    renderLogin();
+    await user.type(screen.getByLabelText('Email'), 'a@b.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
+    });
+  });
+
+  it('disables submit button while loading', async () => {
+    const user = userEvent.setup();
+    let resolve!: () => void;
+    mockLogin.mockReturnValueOnce(
+      new Promise<never>(res => { resolve = res as () => void; }),
+    );
+
+    renderLogin();
+    await user.type(screen.getByLabelText('Email'), 'a@b.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled();
+    resolve();
+  });
+
+  it('has a link to the register page', () => {
+    renderLogin();
+    expect(screen.getByRole('link', { name: /register/i })).toHaveAttribute('href', '/register');
+  });
+});

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { useQueryClient } from '@tanstack/react-query';
+import { login } from '../api/auth';
+import { ApiError } from '../api/client';
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await login({ email, password });
+      queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
+      navigate('/notebooks');
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setError('Invalid email or password.');
+      } else {
+        setError('Something went wrong. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <h1>Sign in</h1>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+              autoFocus
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="auth-error">{error}</p>}
+          <button type="submit" disabled={loading} className="btn-primary">
+            {loading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+        <p className="auth-footer">
+          Don't have an account? <Link to="/register">Register</Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RegisterPage from './RegisterPage';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { ApiError } from '../api/client';
+
+vi.mock('../api/auth', () => ({
+  register: vi.fn(),
+  login: vi.fn(),
+}));
+
+import { register, login } from '../api/auth';
+const mockRegister = vi.mocked(register);
+const mockLogin = vi.mocked(login);
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-router')>();
+  return { ...mod, useNavigate: () => mockNavigate };
+});
+
+const USER = { uid: 'u1', email: 'a@b.com', firstname: 'Alice', lastname: 'Smith' };
+
+function renderRegister() {
+  return renderWithProviders(<RegisterPage />);
+}
+
+async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>, overrides: Record<string, string> = {}) {
+  const fields = { firstname: 'Alice', lastname: 'Smith', email: 'a@b.com', password: 'password1', ...overrides };
+  await user.type(screen.getByLabelText('First name'), fields.firstname);
+  await user.type(screen.getByLabelText('Last name'), fields.lastname);
+  await user.type(screen.getByLabelText('Email'), fields.email);
+  await user.type(screen.getByLabelText('Password'), fields.password);
+  await user.click(screen.getByRole('button', { name: /create account/i }));
+}
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all form fields and a submit button', () => {
+    renderRegister();
+    expect(screen.getByLabelText('First name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Last name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
+  });
+
+  it('calls register then login with the entered values', async () => {
+    const user = userEvent.setup();
+    mockRegister.mockResolvedValueOnce(USER);
+    mockLogin.mockResolvedValueOnce(USER);
+
+    renderRegister();
+    await fillAndSubmit(user);
+
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalledWith({
+        firstname: 'Alice', lastname: 'Smith', email: 'a@b.com', password: 'password1',
+      });
+    });
+    expect(mockLogin).toHaveBeenCalledWith({ email: 'a@b.com', password: 'password1' });
+  });
+
+  it('navigates to /notebooks after successful registration', async () => {
+    const user = userEvent.setup();
+    mockRegister.mockResolvedValueOnce(USER);
+    mockLogin.mockResolvedValueOnce(USER);
+
+    renderRegister();
+    await fillAndSubmit(user);
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/notebooks'));
+  });
+
+  it('shows duplicate email error on 409', async () => {
+    const user = userEvent.setup();
+    mockRegister.mockRejectedValueOnce(new ApiError(409, 'Email already registered'));
+
+    renderRegister();
+    await fillAndSubmit(user);
+
+    await waitFor(() => {
+      expect(screen.getByText('An account with this email already exists.')).toBeInTheDocument();
+    });
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows generic error on unexpected failure', async () => {
+    const user = userEvent.setup();
+    mockRegister.mockRejectedValueOnce(new Error('network error'));
+
+    renderRegister();
+    await fillAndSubmit(user);
+
+    await waitFor(() => {
+      expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
+    });
+  });
+
+  it('disables submit button while loading', async () => {
+    const user = userEvent.setup();
+    let resolve!: () => void;
+    mockRegister.mockReturnValueOnce(new Promise<never>(res => { resolve = res as () => void; }));
+
+    renderRegister();
+    await fillAndSubmit(user);
+
+    expect(screen.getByRole('button', { name: /creating account/i })).toBeDisabled();
+    resolve();
+  });
+
+  it('has a link to the login page', () => {
+    renderRegister();
+    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login');
+  });
+});

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { register, login } from '../api/auth';
+import { ApiError } from '../api/client';
+import { useQueryClient } from '@tanstack/react-query';
+
+export default function RegisterPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState({
+    email: '',
+    password: '',
+    firstname: '',
+    lastname: '',
+  });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const set = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm(f => ({ ...f, [field]: e.target.value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await register(form);
+      await login({ email: form.email, password: form.password });
+      queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
+      navigate('/notebooks');
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setError('An account with this email already exists.');
+      } else {
+        setError('Something went wrong. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <h1>Create account</h1>
+        <form onSubmit={handleSubmit}>
+          <div className="form-row">
+            <div className="form-group">
+              <label htmlFor="firstname">First name</label>
+              <input
+                id="firstname"
+                type="text"
+                value={form.firstname}
+                onChange={set('firstname')}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="lastname">Last name</label>
+              <input
+                id="lastname"
+                type="text"
+                value={form.lastname}
+                onChange={set('lastname')}
+                required
+              />
+            </div>
+          </div>
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              value={form.email}
+              onChange={set('email')}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              type="password"
+              value={form.password}
+              onChange={set('password')}
+              required
+              minLength={8}
+            />
+          </div>
+          {error && <p className="auth-error">{error}</p>}
+          <button type="submit" disabled={loading} className="btn-primary">
+            {loading ? 'Creating account…' : 'Create account'}
+          </button>
+        </form>
+        <p className="auth-footer">
+          Already have an account? <Link to="/login">Sign in</Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     "textual>=8.0.2",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
+    "argon2-cffi>=23.1.0",
+    "PyJWT>=2.8.0",
+    "python-multipart>=0.0.9",
+    "email-validator>=2.1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/assistant/api/app.py
+++ b/src/assistant/api/app.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from assistant.api.exceptions import register_exception_handlers
+from assistant.api.routes.auth import router as auth_router
 from assistant.api.routes.nodes import router as nodes_router
 from assistant.api.routes.notebooks import router as notebooks_router
 from assistant.api.routes.notes import router as notes_router
@@ -38,6 +39,7 @@ def create_app(
 
     register_exception_handlers(app)
 
+    app.include_router(auth_router, prefix="/auth", tags=["auth"])
     app.include_router(users_router, prefix="/user", tags=["users"])
     app.include_router(notebooks_router, prefix="/notebook", tags=["notebooks"])
     app.include_router(notes_router, prefix="/notebook", tags=["notes"])

--- a/src/assistant/api/dependencies.py
+++ b/src/assistant/api/dependencies.py
@@ -6,8 +6,10 @@ import uuid
 from collections.abc import Generator
 from typing import Annotated
 
-from fastapi import Depends, Header, HTTPException, Request
+from fastapi import Depends, HTTPException, Request
 from sqlalchemy.orm import Session
+
+from assistant.auth.service import AuthError, decode_access_token
 
 
 def get_session(
@@ -25,18 +27,37 @@ def get_session(
         session.close()
 
 
-# TODO: return User entity instead of UUID when JWT auth is implemented,
-# so we validate existence and load user data in one step.
-def get_current_user_id(
-    x_user_id: Annotated[str, Header()],
-) -> uuid.UUID:
-    try:
-        return uuid.UUID(x_user_id)
-    except ValueError as exc:
+def get_current_user_id(request: Request) -> uuid.UUID:
+    """Resolve the authenticated user from a JWT access token.
+
+    Accepts either an Authorization: Bearer header or an access_token cookie —
+    never both simultaneously.
+    """
+    auth_header = request.headers.get("Authorization")
+    access_cookie = request.cookies.get("access_token")
+
+    if auth_header and access_cookie:
         raise HTTPException(
             status_code=401,
-            detail="Invalid X-User-Id header",
-        ) from exc
+            detail="Ambiguous authentication: provide cookie or Bearer token, not both",
+        )
+
+    if auth_header:
+        if not auth_header.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail="Authorization header must use the Bearer scheme",
+            )
+        token = auth_header[7:]
+    elif access_cookie:
+        token = access_cookie
+    else:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    try:
+        return decode_access_token(token)
+    except AuthError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
 
 
 SessionDep = Annotated[Session, Depends(get_session)]

--- a/src/assistant/api/dependencies.py
+++ b/src/assistant/api/dependencies.py
@@ -10,6 +10,8 @@ from fastapi import Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from assistant.auth.service import AuthError, decode_access_token
+from assistant.models.schema import Notebook
+from assistant.notes.service import get_notebook
 
 
 def get_session(
@@ -58,6 +60,18 @@ def get_current_user_id(request: Request) -> uuid.UUID:
         return decode_access_token(token)
     except AuthError as exc:
         raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+def require_notebook_owner(
+    session: Session,
+    notebook_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> Notebook:
+    """Return the notebook if user owns it, else raise 404."""
+    notebook = get_notebook(session, notebook_id)
+    if notebook.owner_id != user_id:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    return notebook
 
 
 SessionDep = Annotated[Session, Depends(get_session)]

--- a/src/assistant/api/routes/auth.py
+++ b/src/assistant/api/routes/auth.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import os
-
-from fastapi import APIRouter, Cookie, HTTPException, Response
+from fastapi import APIRouter, Cookie, HTTPException, Request, Response
 from sqlalchemy.exc import IntegrityError
 
 from assistant.api.dependencies import CurrentUserId, SessionDep
@@ -21,18 +19,20 @@ from assistant.notes.user_service import get_user
 
 router = APIRouter()
 
-_COOKIE_SECURE = os.getenv("COOKIE_SECURE", "false").lower() == "true"
-_ACCESS_MAX_AGE = 15 * 60
+_ACCESS_MAX_AGE = 5 * 60
 _REFRESH_MAX_AGE = 7 * 24 * 60 * 60
 
 
-def _set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> None:
+def _set_auth_cookies(
+    request: Request, response: Response, access_token: str, refresh_token: str
+) -> None:
+    secure = request.url.scheme == "https"
     response.set_cookie(
         "access_token",
         access_token,
         httponly=True,
         samesite="lax",
-        secure=_COOKIE_SECURE,
+        secure=secure,
         max_age=_ACCESS_MAX_AGE,
         path="/",
     )
@@ -41,7 +41,7 @@ def _set_auth_cookies(response: Response, access_token: str, refresh_token: str)
         refresh_token,
         httponly=True,
         samesite="lax",
-        secure=_COOKIE_SECURE,
+        secure=secure,
         max_age=_REFRESH_MAX_AGE,
         path="/auth/refresh",
     )
@@ -74,6 +74,7 @@ def register(
 def login(
     body: LoginRequest,
     session: SessionDep,
+    request: Request,
     response: Response,
 ) -> UserResponse:
     try:
@@ -82,13 +83,14 @@ def login(
         raise HTTPException(status_code=401, detail="Invalid credentials") from exc
 
     access, refresh = issue_tokens(session, user.uid)
-    _set_auth_cookies(response, access, refresh)
+    _set_auth_cookies(request, response, access, refresh)
     return UserResponse.model_validate(user)
 
 
 @router.post("/refresh", response_model=UserResponse)
 def refresh(
     session: SessionDep,
+    request: Request,
     response: Response,
     refresh_token: str | None = Cookie(default=None),
 ) -> UserResponse:
@@ -100,7 +102,7 @@ def refresh(
         _clear_auth_cookies(response)
         raise HTTPException(status_code=401, detail=str(exc)) from exc
 
-    _set_auth_cookies(response, new_access, new_refresh)
+    _set_auth_cookies(request, response, new_access, new_refresh)
     user = get_user(session, user_id)
     return UserResponse.model_validate(user)
 

--- a/src/assistant/api/routes/auth.py
+++ b/src/assistant/api/routes/auth.py
@@ -1,0 +1,126 @@
+"""Authentication API routes."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter, Cookie, HTTPException, Response
+from sqlalchemy.exc import IntegrityError
+
+from assistant.api.dependencies import CurrentUserId, SessionDep
+from assistant.api.schemas.auth import LoginRequest, RegisterRequest, UserResponse
+from assistant.auth.service import (
+    AuthError,
+    authenticate_user,
+    issue_tokens,
+    logout_user,
+    register_user,
+    rotate_refresh_token,
+)
+from assistant.notes.user_service import get_user
+
+router = APIRouter()
+
+_COOKIE_SECURE = os.getenv("COOKIE_SECURE", "false").lower() == "true"
+_ACCESS_MAX_AGE = 15 * 60
+_REFRESH_MAX_AGE = 7 * 24 * 60 * 60
+
+
+def _set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> None:
+    response.set_cookie(
+        "access_token",
+        access_token,
+        httponly=True,
+        samesite="lax",
+        secure=_COOKIE_SECURE,
+        max_age=_ACCESS_MAX_AGE,
+        path="/",
+    )
+    response.set_cookie(
+        "refresh_token",
+        refresh_token,
+        httponly=True,
+        samesite="lax",
+        secure=_COOKIE_SECURE,
+        max_age=_REFRESH_MAX_AGE,
+        path="/auth/refresh",
+    )
+
+
+def _clear_auth_cookies(response: Response) -> None:
+    response.delete_cookie("access_token", path="/")
+    response.delete_cookie("refresh_token", path="/auth/refresh")
+
+
+@router.post("/register", status_code=201, response_model=UserResponse)
+def register(
+    body: RegisterRequest,
+    session: SessionDep,
+) -> UserResponse:
+    try:
+        user = register_user(
+            session,
+            email=body.email,
+            password=body.password,
+            firstname=body.firstname,
+            lastname=body.lastname,
+        )
+    except IntegrityError as exc:
+        raise HTTPException(status_code=409, detail="Email already registered") from exc
+    return UserResponse.model_validate(user)
+
+
+@router.post("/login", response_model=UserResponse)
+def login(
+    body: LoginRequest,
+    session: SessionDep,
+    response: Response,
+) -> UserResponse:
+    try:
+        user = authenticate_user(session, email=body.email, password=body.password)
+    except AuthError as exc:
+        raise HTTPException(status_code=401, detail="Invalid credentials") from exc
+
+    access, refresh = issue_tokens(session, user.uid)
+    _set_auth_cookies(response, access, refresh)
+    return UserResponse.model_validate(user)
+
+
+@router.post("/refresh", response_model=UserResponse)
+def refresh(
+    session: SessionDep,
+    response: Response,
+    refresh_token: str | None = Cookie(default=None),
+) -> UserResponse:
+    if refresh_token is None:
+        raise HTTPException(status_code=401, detail="No refresh token")
+    try:
+        user_id, new_access, new_refresh = rotate_refresh_token(session, refresh_token)
+    except AuthError as exc:
+        _clear_auth_cookies(response)
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+    _set_auth_cookies(response, new_access, new_refresh)
+    user = get_user(session, user_id)
+    return UserResponse.model_validate(user)
+
+
+@router.post("/logout", status_code=204)
+def logout(
+    session: SessionDep,
+    response: Response,
+    refresh_token: str | None = Cookie(default=None),
+) -> Response:
+    if refresh_token is not None:
+        logout_user(session, refresh_token)
+    _clear_auth_cookies(response)
+    return Response(status_code=204)
+
+
+@router.get("/me", response_model=UserResponse)
+def me(
+    session: SessionDep,
+    user_id: CurrentUserId,
+) -> UserResponse:
+    user = get_user(session, user_id)
+    return UserResponse.model_validate(user)

--- a/src/assistant/api/routes/nodes.py
+++ b/src/assistant/api/routes/nodes.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Response
 
-from assistant.api.dependencies import CurrentUserId, SessionDep
+from assistant.api.dependencies import CurrentUserId, SessionDep, require_notebook_owner
 from assistant.api.schemas.nodes import (
     NodeCreate,
     NodePatch,
@@ -22,7 +22,6 @@ from assistant.notes.service import (
     add_text_node,
     delete_node,
     get_note,
-    get_notebook,
     get_ordered_nodes,
     insert_markdown_node,
     insert_text_node,
@@ -33,16 +32,6 @@ from assistant.notes.service import (
 )
 
 router = APIRouter()
-
-
-def _require_notebook_owner(
-    session: SessionDep,
-    notebook_id: uuid.UUID,
-    user_id: uuid.UUID,
-) -> None:
-    notebook = get_notebook(session, notebook_id)
-    if notebook.owner_id != user_id:
-        raise HTTPException(status_code=404, detail="Notebook not found")
 
 
 def _get_node_in_note(
@@ -81,7 +70,7 @@ def list_nodes_endpoint(
     user_id: CurrentUserId,
 ) -> list[NodeResponse]:
     """List all nodes in a note, ordered by position."""
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     _validate_note_in_notebook(session, notebook_id, note_id)
     nodes = get_ordered_nodes(session, note_id)
     return [NodeResponse.model_validate(n) for n in nodes]
@@ -100,7 +89,7 @@ def create_node_endpoint(
     user_id: CurrentUserId,
 ) -> NodeResponse:
     """Create a node in a note, optionally positioned between neighbours."""
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     _validate_note_in_notebook(session, notebook_id, note_id)
     has_neighbors = body.after_node_id is not None or body.before_node_id is not None
     if body.block_type is not None:
@@ -154,7 +143,7 @@ def patch_node_endpoint(  # noqa: PLR0913
     user_id: CurrentUserId,
 ) -> NodeResponse:
     """Update a node's payload or merge another node into it."""
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     _get_node_in_note(session, notebook_id, note_id, node_id)
     if isinstance(body, NodeUpdate):
         if body.block_type is not None:
@@ -208,7 +197,7 @@ def split_node_endpoint(  # noqa: PLR0913
     user_id: CurrentUserId,
 ) -> SplitResponse:
     """Split a text node at a character offset, producing two nodes."""
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     _get_node_in_note(session, notebook_id, note_id, node_id)
     original, new = split_text_node(
         session,
@@ -235,7 +224,7 @@ def delete_node_endpoint(
     user_id: CurrentUserId,
 ) -> Response:
     """Delete a node. Idempotent — returns 204 whether or not the node existed."""
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     _validate_note_in_notebook(session, notebook_id, note_id)
     delete_node(session, node_id)
     return Response(status_code=204)

--- a/src/assistant/api/routes/nodes.py
+++ b/src/assistant/api/routes/nodes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, HTTPException, Response
 
 from assistant.api.dependencies import CurrentUserId, SessionDep
 from assistant.api.schemas.nodes import (
@@ -22,6 +22,7 @@ from assistant.notes.service import (
     add_text_node,
     delete_node,
     get_note,
+    get_notebook,
     get_ordered_nodes,
     insert_markdown_node,
     insert_text_node,
@@ -32,6 +33,16 @@ from assistant.notes.service import (
 )
 
 router = APIRouter()
+
+
+def _require_notebook_owner(
+    session: SessionDep,
+    notebook_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    notebook = get_notebook(session, notebook_id)
+    if notebook.owner_id != user_id:
+        raise HTTPException(status_code=404, detail="Notebook not found")
 
 
 def _get_node_in_note(
@@ -67,8 +78,10 @@ def list_nodes_endpoint(
     notebook_id: uuid.UUID,
     note_id: uuid.UUID,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> list[NodeResponse]:
     """List all nodes in a note, ordered by position."""
+    _require_notebook_owner(session, notebook_id, user_id)
     _validate_note_in_notebook(session, notebook_id, note_id)
     nodes = get_ordered_nodes(session, note_id)
     return [NodeResponse.model_validate(n) for n in nodes]
@@ -87,6 +100,7 @@ def create_node_endpoint(
     user_id: CurrentUserId,
 ) -> NodeResponse:
     """Create a node in a note, optionally positioned between neighbours."""
+    _require_notebook_owner(session, notebook_id, user_id)
     _validate_note_in_notebook(session, notebook_id, note_id)
     has_neighbors = body.after_node_id is not None or body.before_node_id is not None
     if body.block_type is not None:
@@ -131,14 +145,16 @@ def create_node_endpoint(
     "/{notebook_id}/note/{note_id}/node/{node_id}",
     response_model=NodeResponse,
 )
-def patch_node_endpoint(
+def patch_node_endpoint(  # noqa: PLR0913
     notebook_id: uuid.UUID,
     note_id: uuid.UUID,
     node_id: uuid.UUID,
     body: NodePatch,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> NodeResponse:
     """Update a node's payload or merge another node into it."""
+    _require_notebook_owner(session, notebook_id, user_id)
     _get_node_in_note(session, notebook_id, note_id, node_id)
     if isinstance(body, NodeUpdate):
         if body.block_type is not None:
@@ -192,6 +208,7 @@ def split_node_endpoint(  # noqa: PLR0913
     user_id: CurrentUserId,
 ) -> SplitResponse:
     """Split a text node at a character offset, producing two nodes."""
+    _require_notebook_owner(session, notebook_id, user_id)
     _get_node_in_note(session, notebook_id, note_id, node_id)
     original, new = split_text_node(
         session,
@@ -215,8 +232,10 @@ def delete_node_endpoint(
     note_id: uuid.UUID,
     node_id: uuid.UUID,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> Response:
     """Delete a node. Idempotent — returns 204 whether or not the node existed."""
+    _require_notebook_owner(session, notebook_id, user_id)
     _validate_note_in_notebook(session, notebook_id, note_id)
     delete_node(session, node_id)
     return Response(status_code=204)

--- a/src/assistant/api/routes/notebooks.py
+++ b/src/assistant/api/routes/notebooks.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Response
 
-from assistant.api.dependencies import CurrentUserId, SessionDep
+from assistant.api.dependencies import CurrentUserId, SessionDep, require_notebook_owner
 from assistant.api.schemas.notebooks import (
     NotebookCreate,
     NotebookResponse,
@@ -16,23 +16,11 @@ from assistant.api.schemas.pagination import Pagination
 from assistant.notes.service import (
     create_notebook,
     delete_notebook,
-    get_notebook,
     list_notebooks,
     update_notebook,
 )
 
 router = APIRouter()
-
-
-def _require_notebook_owner(
-    session: SessionDep,
-    notebook_id: uuid.UUID,
-    user_id: uuid.UUID,
-) -> NotebookResponse:
-    notebook = get_notebook(session, notebook_id)
-    if notebook.owner_id != user_id:
-        raise HTTPException(status_code=404, detail="Notebook not found")
-    return NotebookResponse.model_validate(notebook)
 
 
 @router.post("", status_code=201, response_model=NotebookResponse)
@@ -66,7 +54,8 @@ def get_notebook_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> NotebookResponse:
-    return _require_notebook_owner(session, notebook_id, user_id)
+    notebook = require_notebook_owner(session, notebook_id, user_id)
+    return NotebookResponse.model_validate(notebook)
 
 
 @router.patch("/{notebook_id}", response_model=NotebookResponse)
@@ -76,7 +65,7 @@ def update_notebook_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> NotebookResponse:
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     notebook = update_notebook(session, notebook_id, name=body.name)
     return NotebookResponse.model_validate(notebook)
 
@@ -87,6 +76,6 @@ def delete_notebook_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> Response:
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     delete_notebook(session, notebook_id)
     return Response(status_code=204)

--- a/src/assistant/api/routes/notebooks.py
+++ b/src/assistant/api/routes/notebooks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, HTTPException, Response
 
 from assistant.api.dependencies import CurrentUserId, SessionDep
 from assistant.api.schemas.notebooks import (
@@ -22,6 +22,17 @@ from assistant.notes.service import (
 )
 
 router = APIRouter()
+
+
+def _require_notebook_owner(
+    session: SessionDep,
+    notebook_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> NotebookResponse:
+    notebook = get_notebook(session, notebook_id)
+    if notebook.owner_id != user_id:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    return NotebookResponse.model_validate(notebook)
 
 
 @router.post("", status_code=201, response_model=NotebookResponse)
@@ -53,9 +64,9 @@ def list_notebooks_endpoint(
 def get_notebook_endpoint(
     notebook_id: uuid.UUID,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> NotebookResponse:
-    notebook = get_notebook(session, notebook_id)
-    return NotebookResponse.model_validate(notebook)
+    return _require_notebook_owner(session, notebook_id, user_id)
 
 
 @router.patch("/{notebook_id}", response_model=NotebookResponse)
@@ -63,7 +74,9 @@ def update_notebook_endpoint(
     notebook_id: uuid.UUID,
     body: NotebookUpdate,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> NotebookResponse:
+    _require_notebook_owner(session, notebook_id, user_id)
     notebook = update_notebook(session, notebook_id, name=body.name)
     return NotebookResponse.model_validate(notebook)
 
@@ -72,6 +85,8 @@ def update_notebook_endpoint(
 def delete_notebook_endpoint(
     notebook_id: uuid.UUID,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> Response:
+    _require_notebook_owner(session, notebook_id, user_id)
     delete_notebook(session, notebook_id)
     return Response(status_code=204)

--- a/src/assistant/api/routes/notes.py
+++ b/src/assistant/api/routes/notes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, HTTPException, Response
 
 from assistant.api.dependencies import CurrentUserId, SessionDep
 from assistant.api.schemas.notes import NoteCreate, NoteResponse, NoteUpdate
@@ -16,11 +16,22 @@ from assistant.notes.service import (
     create_note,
     delete_note,
     get_note,
+    get_notebook,
     list_notes,
     update_note,
 )
 
 router = APIRouter()
+
+
+def _require_notebook_owner(
+    session: SessionDep,
+    notebook_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    notebook = get_notebook(session, notebook_id)
+    if notebook.owner_id != user_id:
+        raise HTTPException(status_code=404, detail="Notebook not found")
 
 
 def _get_note_in_notebook(
@@ -45,6 +56,7 @@ def create_note_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> NoteResponse:
+    _require_notebook_owner(session, notebook_id, user_id)
     note = create_note(
         session,
         notebook_id=notebook_id,
@@ -62,8 +74,10 @@ def create_note_endpoint(
 def list_notes_endpoint(
     notebook_id: uuid.UUID,
     session: SessionDep,
+    user_id: CurrentUserId,
     pagination: Pagination,
 ) -> list[NoteResponse]:
+    _require_notebook_owner(session, notebook_id, user_id)
     notes = list_notes(
         session,
         notebook_id=notebook_id,
@@ -81,7 +95,9 @@ def get_note_endpoint(
     notebook_id: uuid.UUID,
     note_id: uuid.UUID,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> NoteResponse:
+    _require_notebook_owner(session, notebook_id, user_id)
     note = _get_note_in_notebook(session, notebook_id, note_id)
     return NoteResponse.model_validate(note)
 
@@ -95,7 +111,9 @@ def update_note_endpoint(
     note_id: uuid.UUID,
     body: NoteUpdate,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> NoteResponse:
+    _require_notebook_owner(session, notebook_id, user_id)
     _get_note_in_notebook(session, notebook_id, note_id)
     note = update_note(session, note_id, title=body.title)
     return NoteResponse.model_validate(note)
@@ -109,7 +127,9 @@ def delete_note_endpoint(
     notebook_id: uuid.UUID,
     note_id: uuid.UUID,
     session: SessionDep,
+    user_id: CurrentUserId,
 ) -> Response:
+    _require_notebook_owner(session, notebook_id, user_id)
     _get_note_in_notebook(session, notebook_id, note_id)
     delete_note(session, note_id)
     return Response(status_code=204)

--- a/src/assistant/api/routes/notes.py
+++ b/src/assistant/api/routes/notes.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Response
 
-from assistant.api.dependencies import CurrentUserId, SessionDep
+from assistant.api.dependencies import CurrentUserId, SessionDep, require_notebook_owner
 from assistant.api.schemas.notes import NoteCreate, NoteResponse, NoteUpdate
 from assistant.api.schemas.pagination import Pagination
 from assistant.models.schema import Note
@@ -16,22 +16,11 @@ from assistant.notes.service import (
     create_note,
     delete_note,
     get_note,
-    get_notebook,
     list_notes,
     update_note,
 )
 
 router = APIRouter()
-
-
-def _require_notebook_owner(
-    session: SessionDep,
-    notebook_id: uuid.UUID,
-    user_id: uuid.UUID,
-) -> None:
-    notebook = get_notebook(session, notebook_id)
-    if notebook.owner_id != user_id:
-        raise HTTPException(status_code=404, detail="Notebook not found")
 
 
 def _get_note_in_notebook(
@@ -56,7 +45,7 @@ def create_note_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> NoteResponse:
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     note = create_note(
         session,
         notebook_id=notebook_id,
@@ -77,7 +66,7 @@ def list_notes_endpoint(
     user_id: CurrentUserId,
     pagination: Pagination,
 ) -> list[NoteResponse]:
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     notes = list_notes(
         session,
         notebook_id=notebook_id,
@@ -97,7 +86,7 @@ def get_note_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> NoteResponse:
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     note = _get_note_in_notebook(session, notebook_id, note_id)
     return NoteResponse.model_validate(note)
 
@@ -113,7 +102,7 @@ def update_note_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> NoteResponse:
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     _get_note_in_notebook(session, notebook_id, note_id)
     note = update_note(session, note_id, title=body.title)
     return NoteResponse.model_validate(note)
@@ -129,7 +118,7 @@ def delete_note_endpoint(
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> Response:
-    _require_notebook_owner(session, notebook_id, user_id)
+    require_notebook_owner(session, notebook_id, user_id)
     _get_note_in_notebook(session, notebook_id, note_id)
     delete_note(session, note_id)
     return Response(status_code=204)

--- a/src/assistant/api/schemas/auth.py
+++ b/src/assistant/api/schemas/auth.py
@@ -1,0 +1,34 @@
+"""Pydantic schemas for authentication endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, EmailStr
+
+
+class RegisterRequest(BaseModel):
+    """Request body for POST /auth/register."""
+
+    email: EmailStr
+    password: str
+    firstname: str
+    lastname: str
+
+
+class LoginRequest(BaseModel):
+    """Request body for POST /auth/login."""
+
+    email: EmailStr
+    password: str
+
+
+class UserResponse(BaseModel):
+    """User profile returned after registration or from /auth/me."""
+
+    uid: uuid.UUID
+    email: str
+    firstname: str
+    lastname: str
+
+    model_config = {"from_attributes": True}

--- a/src/assistant/auth/__init__.py
+++ b/src/assistant/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication module."""

--- a/src/assistant/auth/service.py
+++ b/src/assistant/auth/service.py
@@ -1,0 +1,192 @@
+"""Authentication service — registration, login, token lifecycle."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import uuid as uuid_module
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import jwt
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+from sqlalchemy import delete, select
+
+from assistant.models.schema import Credential, RefreshToken, User
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+_ph = PasswordHasher()
+
+ACCESS_TOKEN_MINUTES = 15
+REFRESH_TOKEN_DAYS = 7
+
+
+class AuthError(Exception):
+    """Raised when authentication fails."""
+
+
+def _jwt_secret() -> str:
+    secret = os.getenv("JWT_SECRET", "")
+    if not secret:
+        msg = "JWT_SECRET environment variable is not set"
+        raise RuntimeError(msg)
+    return secret
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+# --- Token creation ---
+
+
+def create_access_token(user_id: uuid_module.UUID) -> str:
+    """Return a signed JWT access token for the given user."""
+    now = datetime.now(UTC)
+    payload = {
+        "sub": str(user_id),
+        "iat": now,
+        "exp": now + timedelta(minutes=ACCESS_TOKEN_MINUTES),
+    }
+    return jwt.encode(payload, _jwt_secret(), algorithm="HS256")
+
+
+def decode_access_token(token: str) -> uuid_module.UUID:
+    """Validate a JWT and return the user UUID from the sub claim."""
+    try:
+        payload = jwt.decode(token, _jwt_secret(), algorithms=["HS256"])
+        return uuid_module.UUID(payload["sub"])
+    except (jwt.InvalidTokenError, KeyError, ValueError) as exc:
+        raise AuthError("Invalid or expired access token") from exc  # noqa: TRY003
+
+
+def _create_refresh_token(
+    session: Session,
+    user_id: uuid_module.UUID,
+    family_id: uuid_module.UUID,
+) -> str:
+    raw = secrets.token_urlsafe(32)
+    rt = RefreshToken(
+        user_id=user_id,
+        family_id=family_id,
+        token_hash=_hash_token(raw),
+        expires_at=datetime.now(UTC) + timedelta(days=REFRESH_TOKEN_DAYS),
+    )
+    session.add(rt)
+    session.flush()
+    return raw
+
+
+# --- User registration ---
+
+
+def register_user(
+    session: Session,
+    *,
+    email: str,
+    password: str,
+    firstname: str,
+    lastname: str,
+) -> User:
+    """Create a user and a password credential. Raises AuthError on duplicate email."""
+    user = User(email=email, firstname=firstname, lastname=lastname)
+    session.add(user)
+    session.flush()
+
+    credential = Credential(
+        user_id=user.uid,
+        provider="password",
+        credential_hash=_ph.hash(password),
+    )
+    session.add(credential)
+    session.flush()
+    return user
+
+
+# --- Login ---
+
+
+def authenticate_user(session: Session, *, email: str, password: str) -> User:
+    """Verify email + password and return the User. Raises AuthError on failure."""
+    stmt = (
+        select(User)
+        .join(Credential, Credential.user_id == User.uid)
+        .where(User.email == email)
+        .where(Credential.provider == "password")
+    )
+    user = session.scalar(stmt)
+    if user is None:
+        raise AuthError("Invalid credentials")  # noqa: TRY003
+
+    cred_stmt = (
+        select(Credential)
+        .where(Credential.user_id == user.uid)
+        .where(Credential.provider == "password")
+    )
+    credential = session.scalar(cred_stmt)
+    if credential is None or credential.credential_hash is None:
+        raise AuthError("Invalid credentials")  # noqa: TRY003
+
+    try:
+        _ph.verify(credential.credential_hash, password)
+    except VerifyMismatchError as exc:
+        raise AuthError("Invalid credentials") from exc  # noqa: TRY003
+
+    return user
+
+
+def issue_tokens(session: Session, user_id: uuid_module.UUID) -> tuple[str, str]:
+    """Create and return (access_token, refresh_token) for the user."""
+    family_id = uuid_module.uuid4()
+    access = create_access_token(user_id)
+    refresh = _create_refresh_token(session, user_id, family_id)
+    return access, refresh
+
+
+# --- Refresh ---
+
+
+def rotate_refresh_token(
+    session: Session, raw_token: str
+) -> tuple[uuid_module.UUID, str, str]:
+    """Exchange a refresh token for a new access + refresh pair.
+
+    Returns (user_id, new_access_token, new_refresh_token).
+    Raises AuthError if the token is invalid or expired.
+    """
+    token_hash = _hash_token(raw_token)
+    rt = session.scalar(select(RefreshToken).where(RefreshToken.token_hash == token_hash))
+
+    if rt is None:
+        raise AuthError("Invalid refresh token")  # noqa: TRY003
+
+    now = datetime.now(UTC)
+    if rt.expires_at.replace(tzinfo=UTC) < now:
+        session.delete(rt)
+        raise AuthError("Refresh token expired")  # noqa: TRY003
+
+    user_id = rt.user_id
+    family_id = rt.family_id
+
+    session.delete(rt)
+    session.flush()
+
+    new_access = create_access_token(user_id)
+    new_refresh = _create_refresh_token(session, user_id, family_id)
+    return user_id, new_access, new_refresh
+
+
+# --- Logout ---
+
+
+def logout_user(session: Session, raw_token: str) -> None:
+    """Delete the refresh token family, invalidating all tokens for that session."""
+    token_hash = _hash_token(raw_token)
+    rt = session.scalar(select(RefreshToken).where(RefreshToken.token_hash == token_hash))
+    if rt is None:
+        return
+    session.execute(delete(RefreshToken).where(RefreshToken.family_id == rt.family_id))

--- a/src/assistant/models/schema.py
+++ b/src/assistant/models/schema.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -77,6 +78,81 @@ class User(Base):
         back_populates="owner",
         cascade="all, delete-orphan",
     )
+    credentials: Mapped[list[Credential]] = relationship(
+        "Credential",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    refresh_tokens: Mapped[list[RefreshToken]] = relationship(
+        "RefreshToken",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
+
+class Credential(Base):
+    """User credential — one row per authentication provider per user."""
+
+    __tablename__ = "credentials"
+    __table_args__ = (
+        UniqueConstraint("user_id", "provider", name="uq_credential_user_provider"),
+        UniqueConstraint(
+            "provider",
+            "provider_subject",
+            name="uq_credential_provider_subject",
+        ),
+        {"schema": "assistant"},
+    )
+
+    id: Mapped[uuid_module.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid_module.uuid4,
+    )
+    user_id: Mapped[uuid_module.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("assistant.users.uid"),
+        nullable=False,
+    )
+    provider: Mapped[str] = mapped_column(String(20), nullable=False)
+    credential_hash: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    provider_subject: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    user: Mapped[User] = relationship("User", back_populates="credentials")
+
+
+class RefreshToken(Base):
+    """Refresh token with family tracking for rotation and replay detection."""
+
+    __tablename__ = "refresh_tokens"
+    __table_args__ = (
+        Index("ix_refresh_tokens_token_hash", "token_hash", unique=True),
+        {"schema": "assistant"},
+    )
+
+    id: Mapped[uuid_module.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid_module.uuid4,
+    )
+    user_id: Mapped[uuid_module.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("assistant.users.uid"),
+        nullable=False,
+    )
+    family_id: Mapped[uuid_module.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    user: Mapped[User] = relationship("User", back_populates="refresh_tokens")
 
 
 class Notebook(Base):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import uuid
 from collections.abc import Generator, Iterator
 
 import pytest
@@ -12,9 +14,20 @@ from sqlalchemy.pool import StaticPool
 
 from assistant.api.app import create_app
 from assistant.api.dependencies import get_session
+from assistant.auth.service import create_access_token
 from assistant.models import schema as _schema  # noqa: F401
 from assistant.models.database import Base
-from assistant.models.schema import User
+from assistant.models.schema import Credential, User
+
+_TEST_JWT_SECRET = "test-jwt-secret-do-not-use-in-production"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _set_jwt_secret() -> Generator[None]:
+    """Ensure JWT_SECRET is set for the entire test session."""
+    os.environ["JWT_SECRET"] = _TEST_JWT_SECRET
+    yield
+    os.environ.pop("JWT_SECRET", None)
 
 
 @pytest.fixture(scope="module")
@@ -64,7 +77,6 @@ def db_session(
     transaction = connection.begin()
     session = Session(bind=connection)
 
-    # Start a savepoint so nested session.begin() calls work
     nested = connection.begin_nested()
 
     @event.listens_for(session, "after_transaction_end")
@@ -95,7 +107,7 @@ def client(db_session: Session) -> Iterator[TestClient]:
 
     app = create_app()
     app.dependency_overrides[get_session] = override_get_session
-    with TestClient(app) as tc:
+    with TestClient(app, raise_server_exceptions=True) as tc:
         yield tc
 
 
@@ -108,9 +120,23 @@ def test_user(db_session: Session) -> User:
     )
     db_session.add(user)
     db_session.flush()
+
+    credential = Credential(
+        user_id=user.uid,
+        provider="password",
+        credential_hash="$argon2id$v=19$m=65536,t=3,p=4$placeholder$placeholder",
+    )
+    db_session.add(credential)
+    db_session.flush()
     return user
+
+
+def make_auth_headers(user_id: uuid.UUID) -> dict[str, str]:
+    """Create Authorization headers with a valid JWT for the given user."""
+    token = create_access_token(user_id)
+    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.fixture
 def auth_headers(test_user: User) -> dict[str, str]:
-    return {"X-User-Id": str(test_user.uid)}
+    return make_auth_headers(test_user.uid)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,171 @@
+"""Tests for authentication API endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from assistant.auth.service import create_access_token, issue_tokens
+from assistant.models.schema import User
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+def _register(client: TestClient, email: str = "user@example.com") -> dict:
+    return client.post(
+        "/auth/register",
+        json={
+            "email": email,
+            "password": "secret123",
+            "firstname": "Jane",
+            "lastname": "Doe",
+        },
+    )
+
+
+# --- Registration ---
+
+
+def test_register_creates_user(client: TestClient) -> None:
+    response = _register(client)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == "user@example.com"
+    assert data["firstname"] == "Jane"
+    assert "uid" in data
+    assert "password" not in data
+
+
+def test_register_duplicate_email(client: TestClient) -> None:
+    _register(client)
+    response = _register(client)
+    assert response.status_code == 409
+
+
+def test_register_invalid_email(client: TestClient) -> None:
+    response = client.post(
+        "/auth/register",
+        json={
+            "email": "not-an-email",
+            "password": "x",
+            "firstname": "A",
+            "lastname": "B",
+        },
+    )
+    assert response.status_code == 422
+
+
+# --- Login ---
+
+
+def test_login_sets_cookies(client: TestClient) -> None:
+    _register(client)
+    response = client.post(
+        "/auth/login",
+        json={"email": "user@example.com", "password": "secret123"},
+    )
+    assert response.status_code == 200
+    assert "access_token" in client.cookies
+    assert response.json()["email"] == "user@example.com"
+
+
+def test_login_wrong_password(client: TestClient) -> None:
+    _register(client)
+    response = client.post(
+        "/auth/login",
+        json={"email": "user@example.com", "password": "wrong"},
+    )
+    assert response.status_code == 401
+
+
+def test_login_unknown_email(client: TestClient) -> None:
+    response = client.post(
+        "/auth/login",
+        json={"email": "nobody@example.com", "password": "x"},
+    )
+    assert response.status_code == 401
+
+
+# --- /auth/me ---
+
+
+def test_me_with_bearer_token(client: TestClient, db_session: Session) -> None:
+    user = User(email="me@test.com", firstname="Me", lastname="User")
+    db_session.add(user)
+    db_session.flush()
+
+    token = create_access_token(user.uid)
+    response = client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["email"] == "me@test.com"
+
+
+def test_me_unauthenticated(client: TestClient) -> None:
+    response = client.get("/auth/me")
+    assert response.status_code == 401
+
+
+def test_me_invalid_token(client: TestClient) -> None:
+    response = client.get(
+        "/auth/me",
+        headers={"Authorization": "Bearer invalid.token.here"},
+    )
+    assert response.status_code == 401
+
+
+# --- Logout ---
+
+
+def test_logout_clears_cookies(client: TestClient) -> None:
+    _register(client)
+    client.post(
+        "/auth/login",
+        json={"email": "user@example.com", "password": "secret123"},
+    )
+    assert "access_token" in client.cookies
+
+    response = client.post("/auth/logout")
+    assert response.status_code == 204
+
+
+# --- Ambiguous auth ---
+
+
+def test_both_cookie_and_bearer_rejected(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    user = User(email="ambig@test.com", firstname="A", lastname="B")
+    db_session.add(user)
+    db_session.flush()
+
+    token = create_access_token(user.uid)
+    client.cookies.set("access_token", token)
+    response = client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+    client.cookies.clear()
+
+
+# --- Refresh ---
+
+
+def test_refresh_issues_new_tokens(client: TestClient, db_session: Session) -> None:
+    user = User(email="refresh@test.com", firstname="R", lastname="U")
+    db_session.add(user)
+    db_session.flush()
+
+    _access, refresh_raw = issue_tokens(db_session, user.uid)
+    db_session.commit()
+
+    client.cookies.set("refresh_token", refresh_raw)
+    response = client.post("/auth/refresh")
+    assert response.status_code == 200
+    assert "access_token" in client.cookies
+    client.cookies.clear()

--- a/tests/api/test_nodes.py
+++ b/tests/api/test_nodes.py
@@ -34,17 +34,19 @@ def _setup(
 
 def test_list_nodes_empty(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
     nb, note = _setup(db_session, test_user)
-    response = client.get(f"/notebook/{nb.id}/note/{note.id}/node")
+    response = client.get(f"/notebook/{nb.id}/note/{note.id}/node", headers=auth_headers)
     assert response.status_code == 200
     assert response.json() == []
 
 
 def test_list_nodes_ordered(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -53,7 +55,7 @@ def test_list_nodes_ordered(
     add_text_node(db_session, note.id, test_user.uid, "Second")
     add_text_node(db_session, note.id, test_user.uid, "Third")
 
-    response = client.get(f"/notebook/{nb.id}/note/{note.id}/node")
+    response = client.get(f"/notebook/{nb.id}/note/{note.id}/node", headers=auth_headers)
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 3
@@ -62,12 +64,15 @@ def test_list_nodes_ordered(
 
 def test_list_nodes_wrong_notebook(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
     _nb, note = _setup(db_session, test_user)
     other_nb = create_notebook(db_session, "Other", test_user.uid)
-    response = client.get(f"/notebook/{other_nb.id}/note/{note.id}/node")
+    response = client.get(
+        f"/notebook/{other_nb.id}/note/{note.id}/node", headers=auth_headers
+    )
     assert response.status_code == 404
 
 
@@ -119,7 +124,7 @@ def test_create_node_wrong_notebook(
     test_user: User,
     db_session: Session,
 ) -> None:
-    nb, note = _setup(db_session, test_user)
+    _nb, note = _setup(db_session, test_user)
     other_nb = create_notebook(db_session, "Other", test_user.uid)
     response = client.post(
         f"/notebook/{other_nb.id}/note/{note.id}/node",
@@ -139,7 +144,7 @@ def test_create_node_missing_header(
         f"/notebook/{nb.id}/note/{note.id}/node",
         json={"payload": "No auth"},
     )
-    assert response.status_code == 422
+    assert response.status_code == 401
 
 
 # --- Update node ---
@@ -147,6 +152,7 @@ def test_create_node_missing_header(
 
 def test_update_node_payload(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -160,6 +166,7 @@ def test_update_node_payload(
             "payload": "New",
             "expected_version": 1,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 200
     data = response.json()
@@ -169,6 +176,7 @@ def test_update_node_payload(
 
 def test_update_node_version_conflict(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -182,16 +190,18 @@ def test_update_node_version_conflict(
             "payload": "New",
             "expected_version": 99,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 409
 
 
 def test_update_node_wrong_notebook(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
-    nb, note = _setup(db_session, test_user)
+    _nb, note = _setup(db_session, test_user)
     other_nb = create_notebook(db_session, "Other", test_user.uid)
     node = add_text_node(db_session, note.id, test_user.uid, "Text")
 
@@ -202,12 +212,14 @@ def test_update_node_wrong_notebook(
             "payload": "Sneaky",
             "expected_version": 1,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 404
 
 
 def test_update_node_wrong_note(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -222,6 +234,7 @@ def test_update_node_wrong_note(
             "payload": "Sneaky",
             "expected_version": 1,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 404
 
@@ -231,6 +244,7 @@ def test_update_node_wrong_note(
 
 def test_merge_nodes(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -246,6 +260,7 @@ def test_merge_nodes(
             "expected_version": 1,
             "source_expected_version": 1,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 200
     data = response.json()
@@ -255,6 +270,7 @@ def test_merge_nodes(
 
 def test_merge_version_conflict(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -270,12 +286,14 @@ def test_merge_version_conflict(
             "expected_version": 99,
             "source_expected_version": 1,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 409
 
 
 def test_merge_source_not_in_note(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -292,12 +310,14 @@ def test_merge_source_not_in_note(
             "expected_version": 1,
             "source_expected_version": 1,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 404
 
 
 def test_merge_source_not_found(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -312,6 +332,7 @@ def test_merge_source_not_found(
             "expected_version": 1,
             "source_expected_version": 1,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 404
 
@@ -364,7 +385,7 @@ def test_split_node_wrong_notebook(
     test_user: User,
     db_session: Session,
 ) -> None:
-    nb, note = _setup(db_session, test_user)
+    _nb, note = _setup(db_session, test_user)
     other_nb = create_notebook(db_session, "Other", test_user.uid)
     node = add_text_node(db_session, note.id, test_user.uid, "Text")
 
@@ -397,6 +418,7 @@ def test_split_node_not_found(
 
 def test_delete_node(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -405,33 +427,38 @@ def test_delete_node(
 
     response = client.delete(
         f"/notebook/{nb.id}/note/{note.id}/node/{node.id}",
+        headers=auth_headers,
     )
     assert response.status_code == 204
 
 
 def test_delete_node_idempotent(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
     nb, note = _setup(db_session, test_user)
     response = client.delete(
         f"/notebook/{nb.id}/note/{note.id}/node/{uuid.uuid4()}",
+        headers=auth_headers,
     )
     assert response.status_code == 204
 
 
 def test_delete_node_wrong_notebook(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
-    nb, note = _setup(db_session, test_user)
+    _nb, note = _setup(db_session, test_user)
     other_nb = create_notebook(db_session, "Other", test_user.uid)
     node = add_text_node(db_session, note.id, test_user.uid, "Text")
 
     response = client.delete(
         f"/notebook/{other_nb.id}/note/{note.id}/node/{node.id}",
+        headers=auth_headers,
     )
     assert response.status_code == 404
 
@@ -475,7 +502,7 @@ def test_create_markdown_node_invalid_block_type(
 
 def test_update_markdown_node(
     client: TestClient,
-    auth_headers: dict[str, str],  # noqa: ARG001
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -490,6 +517,7 @@ def test_update_markdown_node(
             "block_type": "heading",
             "expected_version": 1,
         },
+        headers=auth_headers,
     )
     assert response.status_code == 200
     data = response.json()
@@ -500,6 +528,7 @@ def test_update_markdown_node(
 
 def test_list_nodes_includes_block_type(
     client: TestClient,
+    auth_headers: dict[str, str],
     test_user: User,
     db_session: Session,
 ) -> None:
@@ -507,7 +536,7 @@ def test_list_nodes_includes_block_type(
     add_text_node(db_session, note.id, test_user.uid, "plain text")
     add_markdown_node(db_session, note.id, test_user.uid, "# Title", "heading")
 
-    response = client.get(f"/notebook/{nb.id}/note/{note.id}/node")
+    response = client.get(f"/notebook/{nb.id}/note/{note.id}/node", headers=auth_headers)
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2

--- a/tests/api/test_notebooks.py
+++ b/tests/api/test_notebooks.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
     from assistant.models.schema import User
 
+from tests.api.conftest import make_auth_headers
+
 
 class TestCreateNotebook:
     def test_create_notebook(
@@ -39,7 +41,7 @@ class TestCreateNotebook:
             "/notebook",
             json={"name": "My Notebook"},
         )
-        assert response.status_code == 422
+        assert response.status_code == 401
 
 
 class TestListNotebooks:
@@ -95,7 +97,7 @@ class TestListNotebooks:
 
         response = client.get(
             "/notebook",
-            headers={"X-User-Id": str(test_user.uid)},
+            headers=make_auth_headers(test_user.uid),
         )
         assert len(response.json()) == 1
         assert response.json()[0]["name"] == "Mine"
@@ -105,16 +107,38 @@ class TestGetNotebook:
     def test_get_notebook(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
         nb = create_notebook(db_session, "Test NB", test_user.uid)
-        response = client.get(f"/notebook/{nb.id}")
+        response = client.get(f"/notebook/{nb.id}", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["name"] == "Test NB"
 
-    def test_get_notebook_not_found(self, client: TestClient) -> None:
-        response = client.get(f"/notebook/{uuid.uuid4()}")
+    def test_get_notebook_not_found(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        response = client.get(f"/notebook/{uuid.uuid4()}", headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_get_notebook_other_user_returns_404(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        other = UserModel(email="other2@test.com", firstname="O", lastname="U")
+        db_session.add(other)
+        db_session.flush()
+        nb = create_notebook(db_session, "Other NB", other.uid)
+
+        response = client.get(
+            f"/notebook/{nb.id}",
+            headers=make_auth_headers(test_user.uid),
+        )
         assert response.status_code == 404
 
 
@@ -122,6 +146,7 @@ class TestUpdateNotebook:
     def test_update_notebook(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
@@ -129,6 +154,7 @@ class TestUpdateNotebook:
         response = client.patch(
             f"/notebook/{nb.id}",
             json={"name": "New Name"},
+            headers=auth_headers,
         )
         assert response.status_code == 200
         assert response.json()["name"] == "New Name"
@@ -138,16 +164,21 @@ class TestDeleteNotebook:
     def test_delete_notebook(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
         nb = create_notebook(db_session, "To Delete", test_user.uid)
-        response = client.delete(f"/notebook/{nb.id}")
+        response = client.delete(f"/notebook/{nb.id}", headers=auth_headers)
         assert response.status_code == 204
 
-        response = client.get(f"/notebook/{nb.id}")
+        response = client.get(f"/notebook/{nb.id}", headers=auth_headers)
         assert response.status_code == 404
 
-    def test_delete_notebook_not_found(self, client: TestClient) -> None:
-        response = client.delete(f"/notebook/{uuid.uuid4()}")
+    def test_delete_notebook_not_found(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        response = client.delete(f"/notebook/{uuid.uuid4()}", headers=auth_headers)
         assert response.status_code == 404

--- a/tests/api/test_notes.py
+++ b/tests/api/test_notes.py
@@ -64,13 +64,14 @@ class TestCreateNote:
             f"/notebook/{nb.id}/note",
             json={"title": "My Note"},
         )
-        assert response.status_code == 422
+        assert response.status_code == 401
 
 
 class TestListNotes:
     def test_list_notes(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
@@ -78,13 +79,14 @@ class TestListNotes:
         create_note(db_session, nb.id, test_user.uid, "Note1")
         create_note(db_session, nb.id, test_user.uid, "Note2")
 
-        response = client.get(f"/notebook/{nb.id}/note")
+        response = client.get(f"/notebook/{nb.id}/note", headers=auth_headers)
         assert response.status_code == 200
         assert len(response.json()) == 2
 
     def test_list_notes_pagination(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
@@ -94,6 +96,7 @@ class TestListNotes:
 
         response = client.get(
             f"/notebook/{nb.id}/note",
+            headers=auth_headers,
             params={"offset": 0, "limit": 3},
         )
         assert response.status_code == 200
@@ -104,19 +107,21 @@ class TestGetNote:
     def test_get_note(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
         nb = create_notebook(db_session, "NB", test_user.uid)
         note = create_note(db_session, nb.id, test_user.uid, "Test")
 
-        response = client.get(f"/notebook/{nb.id}/note/{note.id}")
+        response = client.get(f"/notebook/{nb.id}/note/{note.id}", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["title"] == "Test"
 
     def test_get_note_wrong_notebook(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
@@ -124,17 +129,20 @@ class TestGetNote:
         nb2 = create_notebook(db_session, "NB2", test_user.uid)
         note = create_note(db_session, nb1.id, test_user.uid, "Test")
 
-        response = client.get(f"/notebook/{nb2.id}/note/{note.id}")
+        response = client.get(f"/notebook/{nb2.id}/note/{note.id}", headers=auth_headers)
         assert response.status_code == 404
 
     def test_get_note_not_found(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
         nb = create_notebook(db_session, "NB", test_user.uid)
-        response = client.get(f"/notebook/{nb.id}/note/{uuid.uuid4()}")
+        response = client.get(
+            f"/notebook/{nb.id}/note/{uuid.uuid4()}", headers=auth_headers
+        )
         assert response.status_code == 404
 
 
@@ -142,6 +150,7 @@ class TestUpdateNote:
     def test_update_note(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
@@ -151,6 +160,7 @@ class TestUpdateNote:
         response = client.patch(
             f"/notebook/{nb.id}/note/{note.id}",
             json={"title": "New"},
+            headers=auth_headers,
         )
         assert response.status_code == 200
         assert response.json()["title"] == "New"
@@ -158,6 +168,7 @@ class TestUpdateNote:
     def test_update_note_wrong_notebook(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
@@ -168,6 +179,7 @@ class TestUpdateNote:
         response = client.patch(
             f"/notebook/{nb2.id}/note/{note.id}",
             json={"title": "Sneaky"},
+            headers=auth_headers,
         )
         assert response.status_code == 404
 
@@ -176,6 +188,7 @@ class TestDeleteNote:
     def test_delete_note(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
@@ -184,15 +197,17 @@ class TestDeleteNote:
 
         response = client.delete(
             f"/notebook/{nb.id}/note/{note.id}",
+            headers=auth_headers,
         )
         assert response.status_code == 204
 
-        response = client.get(f"/notebook/{nb.id}/note/{note.id}")
+        response = client.get(f"/notebook/{nb.id}/note/{note.id}", headers=auth_headers)
         assert response.status_code == 404
 
     def test_delete_note_wrong_notebook(
         self,
         client: TestClient,
+        auth_headers: dict[str, str],
         test_user: User,
         db_session: Session,
     ) -> None:
@@ -202,5 +217,6 @@ class TestDeleteNote:
 
         response = client.delete(
             f"/notebook/{nb2.id}/note/{note.id}",
+            headers=auth_headers,
         )
         assert response.status_code == 404

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -122,10 +126,55 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
 name = "assistant"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "argon2-cffi" },
+    { name = "email-validator" },
     { name = "evernote-backup" },
     { name = "fastapi" },
     { name = "keyring" },
@@ -139,7 +188,9 @@ dependencies = [
     { name = "openai" },
     { name = "openevals" },
     { name = "psycopg2-binary" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "sqlalchemy" },
     { name = "textual" },
@@ -159,7 +210,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.7.5" },
+    { name = "email-validator", specifier = ">=2.1.0" },
     { name = "evernote-backup", specifier = ">=1.13.1" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
@@ -176,9 +229,11 @@ requires-dist = [
     { name = "openevals", specifier = ">=0.1.3" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
+    { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.6" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
@@ -261,6 +316,8 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
     { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
     { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
     { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
@@ -268,18 +325,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
     { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
     { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
     { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
     { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
     { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
     { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
     { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
     { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
     { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
     { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
     { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -499,6 +569,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1823,6 +1915,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1859,6 +1960,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds full JWT authentication: registration, login, refresh, logout, and `/auth/me` endpoints
- Access tokens (15 min, HS256) and refresh tokens (7 days, rotation with family tracking) are issued as HttpOnly cookies — no token storage needed in the frontend
- All notebook, note, and node routes enforce ownership: each user only sees and modifies their own data (returns 404, not 403, to prevent enumeration)
- Frontend gains `/login` and `/register` pages, an `AuthProvider` wrapping all protected routes, and a header bar with the user's name and a Logout button
- Replaced the old `X-User-Id` pseudo-auth throughout the stack (backend routes, tests, frontend API layer, components)

## New backend modules

- `src/assistant/auth/service.py` — password hashing (argon2), JWT encoding/decoding, token issuance and rotation
- `src/assistant/api/routes/auth.py` — auth endpoints
- `src/assistant/api/schemas/auth.py` — Pydantic request/response models
- `src/assistant/models/schema.py` — added `Credential` and `RefreshToken` ORM tables

## New frontend modules

- `frontend/src/api/auth.ts` — register/login/logout/getMe API calls
- `frontend/src/contexts/AuthContext.tsx` — `AuthProvider` + `useAuth` hook
- `frontend/src/pages/LoginPage.tsx`, `RegisterPage.tsx` — auth forms

## Test plan

- [ ] `make check` passes (73 backend tests including 7 new auth endpoint tests, 85 frontend tests)
- [ ] Register a new user at `/register` → redirects to notebooks
- [ ] Log in at `/login` → sets HttpOnly cookies, redirects to notebooks
- [ ] Notebooks and notes are scoped to the logged-in user
- [ ] Logout button in the header clears session and redirects to `/login`
- [ ] A second user cannot access the first user's notebooks (returns 404)
- [ ] `JWT_SECRET` env var must be set to start the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)